### PR TITLE
[codex] add memory-bank link audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 У репозитория нет собственного build/runtime-приложения. Перед PR достаточно лёгких проверок:
 
 - `rg --files memory-bank examples` для проверки структуры и имён файлов;
+- `python3 scripts/check_memory_bank_index.py` для аудита ссылок, reachability и expected README-индексов внутри `memory-bank/`;
 - `git diff --check` для поиска лишних пробелов и conflict markers;
 - `sed -n '1,120p' path/to/doc.md` для быстрой проверки frontmatter и заголовков;
 - `rg -n "Merchantly|CloudPayments|kiiiosk|Bugsnag" memory-bank` чтобы убедиться, что project-specific детали не протекли обратно в шаблон.

--- a/README.md
+++ b/README.md
@@ -16,33 +16,75 @@
 - `python3 scripts/check_memory_bank_index.py` — аудит достижимости markdown-документов, broken links и expected README-индексов внутри `memory-bank/`.
 - `git diff --check` — проверка лишних пробелов и conflict markers перед PR.
 
-### Проверка навигации `memory-bank`
+### Аудит ссылок и индексации `memory-bank`
 
-Запускайте из корня репозитория:
+Скрипт [`scripts/check_memory_bank_index.py`](scripts/check_memory_bank_index.py) аудирует `memory-bank/` и проверяет:
+
+- broken relative markdown links внутри audit scope;
+- orphan-документы, на которые никто не ссылается внутри scope;
+- достижимость каждого документа от entrypoint'ов по индексной навигации;
+- документы, которые достижимы только глубже порога навигации;
+- contract ожидаемых `README.md`-индексов.
+
+Обычный локальный запуск из корня репозитория:
 
 ```bash
 python3 scripts/check_memory_bank_index.py
 ```
 
-Зачем это нужно:
-
-- поймать broken relative links внутри `memory-bank/` до PR;
-- убедиться, что markdown-документы в `memory-bank/` достижимы из [`memory-bank/README.md`](memory-bank/README.md) через цепочку внутренних ссылок и не стали orphan;
-- проверить, что ожидаемые `README.md`-индексы на месте и остаются index-документами с валидным `purpose`;
-- быстрее находить последствия структурных изменений в шаблоне, когда документ перенесли, переименовали или забыли добавить в навигацию.
-
 Что означает результат:
 
-- exit code `0` — broken links, unreachable docs и нарушения expected index contract не найдены;
-- non-zero exit code — скрипт нашёл проблему, которую нужно исправить до PR.
+- exit code `0` — errors не найдены; warnings по глубине возможны, но аудит считается пройденным;
+- non-zero exit code — найдены проблемы, которые нужно исправить до PR;
+- `--json` — структурированный отчёт, пригодный для последующей автоматической доиндексации другим агентом или инструментом.
 
-Если в downstream-репозитории нужно считать entrypoint не от `memory-bank/README.md`, а от других документов, передайте их явно:
+Параметры запуска:
+
+- `--max-depth N` — порог глубины индексной навигации в прыжках; по умолчанию `3`; документы глубже порога попадают в warning, а не в error;
+- `--entrypoint PATH` — явный entrypoint для аудита; параметр repeatable; принимает repo-relative или scope-relative пути; если передан, используется вместо дефолтного `memory-bank/README.md`;
+- `--scope-root DIR` — меняет audit scope; по умолчанию `memory-bank`;
+- `--repo-root DIR` — явно задаёт корень репозитория; полезно для сетевого запуска или локально установленной копии скрипта;
+- `--json` — печатает только JSON-отчёт.
+
+Примеры:
+
+```bash
+python3 scripts/check_memory_bank_index.py --max-depth 4
+```
 
 ```bash
 python3 scripts/check_memory_bank_index.py \
   --entrypoint README.md \
-  --entrypoint AGENTS.md
+  --entrypoint AGENTS.md \
+  --max-depth 4
 ```
+
+Быстрый запуск по сети без предварительной установки:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dapi/memory-bank/main/scripts/check_memory_bank_index.py \
+  | python3 - --repo-root .
+```
+
+Локальная установка или копирование с GitHub:
+
+1. Скопируйте файл со страницы `scripts/check_memory_bank_index.py` на GitHub или скачайте raw-версию:
+
+```bash
+mkdir -p ./tools
+curl -fsSL \
+  -o ./tools/check_memory_bank_index.py \
+  https://raw.githubusercontent.com/dapi/memory-bank/main/scripts/check_memory_bank_index.py
+chmod +x ./tools/check_memory_bank_index.py
+```
+
+2. Запускайте его из корня downstream-репозитория:
+
+```bash
+python3 ./tools/check_memory_bank_index.py --repo-root .
+```
+
+`macOS` и `Linux`: команды запуска одинаковые. Отличие только в том, куда класть локальную копию, если хочется вызывать скрипт без относительного пути: на Linux чаще используют `~/.local/bin`, на macOS — `~/bin` или любой каталог, добавленный в `PATH`. Если не хотите менять `PATH`, запускайте скрипт через `python3` по полному или относительному пути.
 
 Когда запускать:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 2. Прочитайте и адаптируйте в нем как минимум `domain/`, `engineering/` и `ops/`.
 3. Если нужен ориентир, смотрите конкретный пример в `./examples/merchantly/`.
 
+## Локальные проверки
+
+- `python3 scripts/check_memory_bank_index.py` — аудит достижимости markdown-документов, broken links и expected README-индексов внутри `memory-bank/`.
+- `git diff --check` — проверка лишних пробелов и conflict markers перед PR.
+
 ## Настроечные промпты для агента
 
 Запукаются в новых сессиях

--- a/README.md
+++ b/README.md
@@ -16,6 +16,32 @@
 - `python3 scripts/check_memory_bank_index.py` — аудит достижимости markdown-документов, broken links и expected README-индексов внутри `memory-bank/`.
 - `git diff --check` — проверка лишних пробелов и conflict markers перед PR.
 
+### Проверка навигации `memory-bank`
+
+Запускайте из корня репозитория:
+
+```bash
+python3 scripts/check_memory_bank_index.py
+```
+
+Зачем это нужно:
+
+- поймать broken relative links внутри `memory-bank/` до PR;
+- убедиться, что markdown-документы в `memory-bank/` достижимы из [`memory-bank/README.md`](memory-bank/README.md) через цепочку внутренних ссылок и не стали orphan;
+- проверить, что ожидаемые `README.md`-индексы на месте и остаются index-документами с валидным `purpose`;
+- быстрее находить последствия структурных изменений в шаблоне, когда документ перенесли, переименовали или забыли добавить в навигацию.
+
+Что означает результат:
+
+- exit code `0` — broken links, unreachable docs и нарушения expected index contract не найдены;
+- non-zero exit code — скрипт нашёл проблему, которую нужно исправить до PR.
+
+Когда запускать:
+
+- после добавления, удаления или переименования `.md`-файлов в `memory-bank/`;
+- после правок `README.md`-индексов и относительных ссылок;
+- перед открытием PR с изменениями в template navigation или document structure.
+
 ## Настроечные промпты для агента
 
 Запукаются в новых сессиях

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ python3 scripts/check_memory_bank_index.py
 - exit code `0` — broken links, unreachable docs и нарушения expected index contract не найдены;
 - non-zero exit code — скрипт нашёл проблему, которую нужно исправить до PR.
 
+Если в downstream-репозитории нужно считать entrypoint не от `memory-bank/README.md`, а от других документов, передайте их явно:
+
+```bash
+python3 scripts/check_memory_bank_index.py \
+  --entrypoint README.md \
+  --entrypoint AGENTS.md
+```
+
 Когда запускать:
 
 - после добавления, удаления или переименования `.md`-файлов в `memory-bank/`;

--- a/scripts/check_memory_bank_index.py
+++ b/scripts/check_memory_bank_index.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Audit markdown navigation integrity for the generic memory-bank template.
+
+The script intentionally focuses on `memory-bank/` and avoids downstream
+assumptions from example repositories.
+"""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import re
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+IGNORED_DIRS = {".git", ".hg", ".svn", ".venv", "node_modules", "tmp", "log", "vendor"}
+
+SCOPE_PREFIX = "memory-bank/"
+START_FILES = ("memory-bank/README.md",)
+EXPECTED_INDEXES = (
+    "memory-bank/README.md",
+    "memory-bank/dna/README.md",
+    "memory-bank/domain/README.md",
+    "memory-bank/engineering/README.md",
+    "memory-bank/flows/README.md",
+    "memory-bank/flows/templates/README.md",
+    "memory-bank/ops/README.md",
+    "memory-bank/ops/runbooks/README.md",
+    "memory-bank/prd/README.md",
+    "memory-bank/use-cases/README.md",
+    "memory-bank/adr/README.md",
+    "memory-bank/features/README.md",
+)
+
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---(?:\n|$)", re.DOTALL)
+BULLET_LINK_RE = re.compile(r"^\s*-\s+.*?(?<!\!)\[([^\]]+)\]\(([^)]+)\)")
+
+
+def discover_markdown_files(repo_root: Path) -> dict[str, Path]:
+    files: dict[str, Path] = {}
+    for root, dirs, filenames in os.walk(repo_root):
+        dirs[:] = [directory for directory in dirs if directory not in IGNORED_DIRS]
+        for filename in filenames:
+            if not filename.endswith(".md"):
+                continue
+            full_path = Path(root, filename)
+            relative_path = full_path.relative_to(repo_root).as_posix()
+            files[relative_path] = full_path
+    return files
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def strip_fenced_code_blocks(text: str) -> str:
+    return FENCED_CODE_BLOCK_RE.sub("", text)
+
+
+def normalize_internal_markdown_target(source_path: str, raw_url: str) -> str | None:
+    url = raw_url.strip().strip("<>")
+    if not url or url.startswith(("http://", "https://", "mailto:", "#")):
+        return None
+
+    url = url.split("#", 1)[0].split("?", 1)[0].strip()
+    if not url:
+        return None
+
+    extension = posixpath.splitext(url)[1].lower()
+    if extension and extension != ".md":
+        return None
+
+    base_dir = posixpath.dirname(source_path)
+    if url.startswith("/"):
+        resolved = posixpath.normpath(url.lstrip("/"))
+    else:
+        resolved = posixpath.normpath(posixpath.join(base_dir, url))
+
+    if not extension:
+        resolved = posixpath.join(resolved, "README.md")
+
+    return resolved
+
+
+def extract_internal_markdown_links(source_path: str, text: str) -> list[tuple[str, str]]:
+    stripped_text = strip_fenced_code_blocks(text)
+    links: list[tuple[str, str]] = []
+    for match in MARKDOWN_LINK_RE.finditer(stripped_text):
+        label = match.group(1).strip()
+        target = normalize_internal_markdown_target(source_path, match.group(2))
+        if target is None:
+            continue
+        links.append((target, label))
+    return links
+
+
+def build_link_graph(markdown_files: dict[str, Path]) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    graph: dict[str, set[str]] = defaultdict(set)
+    broken_links: dict[str, set[str]] = defaultdict(set)
+    known_paths = set(markdown_files)
+
+    for source_path, full_path in markdown_files.items():
+        text = read_text(full_path)
+        for target, _label in extract_internal_markdown_links(source_path, text):
+            if target in known_paths:
+                graph[source_path].add(target)
+            elif source_path.startswith(SCOPE_PREFIX):
+                broken_links[source_path].add(target)
+
+    return graph, broken_links
+
+
+def bfs_reachable(graph: dict[str, set[str]], start_files: tuple[str, ...]) -> set[str]:
+    visited: set[str] = set()
+    queue: deque[str] = deque()
+
+    for start_file in start_files:
+        visited.add(start_file)
+        queue.append(start_file)
+
+    while queue:
+        current = queue.popleft()
+        for target in sorted(graph.get(current, set())):
+            if target in visited:
+                continue
+            visited.add(target)
+            queue.append(target)
+
+    return visited
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+
+    frontmatter: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if not line or line.startswith((" ", "\t", "-")) or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        frontmatter[key.strip()] = value.strip().strip("\"'")
+    return frontmatter
+
+
+def annotation_text_for_child_links(index_path: str, text: str) -> list[tuple[str, str]]:
+    section_prefix = posixpath.dirname(index_path)
+    stripped_lines = strip_fenced_code_blocks(text).splitlines()
+    annotations: list[tuple[str, str]] = []
+
+    index_line = 0
+    while index_line < len(stripped_lines):
+        line = stripped_lines[index_line]
+        match = BULLET_LINK_RE.match(line)
+        if not match:
+            index_line += 1
+            continue
+
+        target = normalize_internal_markdown_target(index_path, match.group(2))
+        if target is None:
+            index_line += 1
+            continue
+
+        if section_prefix:
+            child_prefix = f"{section_prefix}/"
+            if not target.startswith(child_prefix):
+                index_line += 1
+                continue
+        elif "/" in target:
+            index_line += 1
+            continue
+
+        fragments: list[str] = []
+        inline_annotation = MARKDOWN_LINK_RE.sub("", line).strip(" -\t:")
+        if inline_annotation:
+            fragments.append(inline_annotation)
+
+        continuation_index = index_line + 1
+        while continuation_index < len(stripped_lines):
+            continuation = stripped_lines[continuation_index]
+            if not continuation.strip():
+                break
+            if continuation.startswith(("  ", "\t")):
+                fragments.append(continuation.strip())
+                continuation_index += 1
+                continue
+            break
+
+        annotations.append((target, " ".join(fragments).strip()))
+        index_line += 1
+
+    return annotations
+
+
+def validate_expected_index(index_path: str, markdown_files: dict[str, Path]) -> list[str]:
+    issues: list[str] = []
+    full_path = markdown_files.get(index_path)
+    if full_path is None:
+        return ["missing expected index file"]
+
+    text = read_text(full_path)
+    frontmatter = parse_frontmatter(text)
+    if not frontmatter:
+        issues.append("missing YAML frontmatter")
+    if frontmatter.get("purpose", "") == "":
+        issues.append("missing 'purpose' in frontmatter")
+    if frontmatter.get("doc_function") != "index":
+        issues.append("expected `doc_function: index`")
+
+    for target, annotation in annotation_text_for_child_links(index_path, text):
+        normalized_annotation = re.sub(r"\s+", " ", annotation).strip(" -:\t").lower()
+        basename = posixpath.basename(target).lower()
+        basename_without_extension = posixpath.splitext(basename)[0]
+        if not normalized_annotation:
+            issues.append(f"missing annotation for child link -> {target}")
+            continue
+        if normalized_annotation in {basename, basename_without_extension}:
+            issues.append(f"annotation repeats filename for child link -> {target}")
+            continue
+        if len(normalized_annotation) < 12:
+            issues.append(f"annotation too short for child link -> {target}")
+
+    return issues
+
+
+def main() -> int:
+    markdown_files = discover_markdown_files(REPO_ROOT)
+    scoped_markdown_paths = sorted(
+        path for path in markdown_files if path.startswith(SCOPE_PREFIX) and path.endswith(".md")
+    )
+
+    missing_start_files = [start_file for start_file in START_FILES if start_file not in markdown_files]
+    if missing_start_files:
+        print("Navigation audit failed: missing start files.")
+        for start_file in missing_start_files:
+            print(f"  - {start_file}")
+        return 1
+
+    graph, broken_links = build_link_graph(markdown_files)
+    reachable = bfs_reachable(graph, START_FILES)
+    unreachable = sorted(path for path in scoped_markdown_paths if path not in reachable)
+
+    exit_code = 0
+
+    print("Memory-bank navigation audit")
+    print(f"Repo root: {REPO_ROOT}")
+    print(f"Scope: {SCOPE_PREFIX}")
+    print(f"Start files: {', '.join(START_FILES)}")
+    print(f"Markdown files in scope: {len(scoped_markdown_paths)}")
+    print()
+
+    scoped_broken_links = {
+        source_path: sorted(targets)
+        for source_path, targets in broken_links.items()
+        if source_path.startswith(SCOPE_PREFIX)
+    }
+    if scoped_broken_links:
+        exit_code = 1
+        print("Broken internal markdown links:")
+        for source_path in sorted(scoped_broken_links):
+            for target in scoped_broken_links[source_path]:
+                print(f"  - {source_path} -> {target}")
+        print()
+    else:
+        print("OK: no broken internal markdown links in scope.")
+        print()
+
+    if unreachable:
+        exit_code = 1
+        print("Unreachable markdown files in scope:")
+        for path in unreachable:
+            print(f"  - {path}")
+        print()
+    else:
+        print("OK: all scoped markdown files are reachable from the configured start files.")
+        print()
+
+    print("Index compliance:")
+    for index_path in EXPECTED_INDEXES:
+        issues = validate_expected_index(index_path, markdown_files)
+        if issues:
+            exit_code = 1
+            print(f"  - {index_path}")
+            for issue in issues:
+                print(f"    * {issue}")
+            continue
+        print(f"  - {index_path}: OK")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_memory_bank_index.py
+++ b/scripts/check_memory_bank_index.py
@@ -7,6 +7,7 @@ assumptions from example repositories.
 
 from __future__ import annotations
 
+import argparse
 import os
 import posixpath
 import re
@@ -18,22 +19,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 IGNORED_DIRS = {".git", ".hg", ".svn", ".venv", "node_modules", "tmp", "log", "vendor"}
 
-SCOPE_PREFIX = "memory-bank/"
-START_FILES = ("memory-bank/README.md",)
-EXPECTED_INDEXES = (
-    "memory-bank/README.md",
-    "memory-bank/dna/README.md",
-    "memory-bank/domain/README.md",
-    "memory-bank/engineering/README.md",
-    "memory-bank/flows/README.md",
-    "memory-bank/flows/templates/README.md",
-    "memory-bank/ops/README.md",
-    "memory-bank/ops/runbooks/README.md",
-    "memory-bank/prd/README.md",
-    "memory-bank/use-cases/README.md",
-    "memory-bank/adr/README.md",
-    "memory-bank/features/README.md",
-)
+DEFAULT_SCOPE_ROOT = "memory-bank"
 
 FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
@@ -56,6 +42,39 @@ def discover_markdown_files(repo_root: Path) -> dict[str, Path]:
 
 def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit markdown navigation integrity for a memory-bank-like documentation tree."
+    )
+    parser.add_argument(
+        "--scope-root",
+        default=DEFAULT_SCOPE_ROOT,
+        help="Repository-relative directory to audit. Default: %(default)s",
+    )
+    parser.add_argument(
+        "--entrypoint",
+        action="append",
+        default=[],
+        help=(
+            "Repository-relative markdown document to use as reachability entrypoint. "
+            "Repeat the option to pass several files."
+        ),
+    )
+    return parser.parse_args()
+
+
+def scope_prefix(scope_root: str) -> str:
+    return f"{scope_root.rstrip('/')}/"
+
+
+def is_scoped_markdown(path: str, scoped_prefix: str) -> bool:
+    return path.startswith(scoped_prefix) and path.endswith(".md")
+
+
+def is_scope_readme(path: str, scoped_prefix: str) -> bool:
+    return is_scoped_markdown(path, scoped_prefix) and posixpath.basename(path) == "README.md"
 
 
 def strip_fenced_code_blocks(text: str) -> str:
@@ -99,7 +118,9 @@ def extract_internal_markdown_links(source_path: str, text: str) -> list[tuple[s
     return links
 
 
-def build_link_graph(markdown_files: dict[str, Path]) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+def build_link_graph(
+    markdown_files: dict[str, Path], scoped_prefix: str
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
     graph: dict[str, set[str]] = defaultdict(set)
     broken_links: dict[str, set[str]] = defaultdict(set)
     known_paths = set(markdown_files)
@@ -109,7 +130,7 @@ def build_link_graph(markdown_files: dict[str, Path]) -> tuple[dict[str, set[str
         for target, _label in extract_internal_markdown_links(source_path, text):
             if target in known_paths:
                 graph[source_path].add(target)
-            elif source_path.startswith(SCOPE_PREFIX):
+            elif source_path.startswith(scoped_prefix):
                 broken_links[source_path].add(target)
 
     return graph, broken_links
@@ -146,6 +167,29 @@ def parse_frontmatter(text: str) -> dict[str, str]:
         key, value = line.split(":", 1)
         frontmatter[key.strip()] = value.strip().strip("\"'")
     return frontmatter
+
+
+def derive_start_files(markdown_files: dict[str, Path], scope_root: str, configured_entrypoints: list[str]) -> tuple[str, ...]:
+    if configured_entrypoints:
+        return tuple(configured_entrypoints)
+
+    fallback_root_index = f"{scope_root.rstrip('/')}/README.md"
+    if fallback_root_index in markdown_files:
+        return (fallback_root_index,)
+
+    return ()
+
+
+def derive_index_paths(markdown_files: dict[str, Path], scoped_prefix: str) -> list[str]:
+    index_paths: list[str] = []
+    for path, full_path in markdown_files.items():
+        if not is_scope_readme(path, scoped_prefix):
+            continue
+        frontmatter = parse_frontmatter(read_text(full_path))
+        if frontmatter.get("doc_function") == "template":
+            continue
+        index_paths.append(path)
+    return sorted(index_paths)
 
 
 def annotation_text_for_child_links(index_path: str, text: str) -> list[tuple[str, str]]:
@@ -197,7 +241,7 @@ def annotation_text_for_child_links(index_path: str, text: str) -> list[tuple[st
     return annotations
 
 
-def validate_expected_index(index_path: str, markdown_files: dict[str, Path]) -> list[str]:
+def validate_index_document(index_path: str, markdown_files: dict[str, Path]) -> list[str]:
     issues: list[str] = []
     full_path = markdown_files.get(index_path)
     if full_path is None:
@@ -229,35 +273,41 @@ def validate_expected_index(index_path: str, markdown_files: dict[str, Path]) ->
 
 
 def main() -> int:
+    args = parse_args()
     markdown_files = discover_markdown_files(REPO_ROOT)
-    scoped_markdown_paths = sorted(
-        path for path in markdown_files if path.startswith(SCOPE_PREFIX) and path.endswith(".md")
-    )
+    scoped_prefix = scope_prefix(args.scope_root)
+    scoped_markdown_paths = sorted(path for path in markdown_files if is_scoped_markdown(path, scoped_prefix))
+    graph, broken_links = build_link_graph(markdown_files, scoped_prefix)
+    start_files = derive_start_files(markdown_files, args.scope_root, args.entrypoint)
+    index_paths = derive_index_paths(markdown_files, scoped_prefix)
 
-    missing_start_files = [start_file for start_file in START_FILES if start_file not in markdown_files]
+    if not start_files:
+        print("Navigation audit failed: no scoped entrypoints were discovered.")
+        return 1
+
+    missing_start_files = [start_file for start_file in start_files if start_file not in markdown_files]
     if missing_start_files:
-        print("Navigation audit failed: missing start files.")
+        print("Navigation audit failed: configured entrypoints are missing.")
         for start_file in missing_start_files:
             print(f"  - {start_file}")
         return 1
 
-    graph, broken_links = build_link_graph(markdown_files)
-    reachable = bfs_reachable(graph, START_FILES)
+    reachable = bfs_reachable(graph, start_files)
     unreachable = sorted(path for path in scoped_markdown_paths if path not in reachable)
 
     exit_code = 0
 
     print("Memory-bank navigation audit")
     print(f"Repo root: {REPO_ROOT}")
-    print(f"Scope: {SCOPE_PREFIX}")
-    print(f"Start files: {', '.join(START_FILES)}")
+    print(f"Scope: {scoped_prefix}")
+    print(f"Start files: {', '.join(start_files)}")
     print(f"Markdown files in scope: {len(scoped_markdown_paths)}")
     print()
 
     scoped_broken_links = {
         source_path: sorted(targets)
         for source_path, targets in broken_links.items()
-        if source_path.startswith(SCOPE_PREFIX)
+        if source_path.startswith(scoped_prefix)
     }
     if scoped_broken_links:
         exit_code = 1
@@ -281,8 +331,8 @@ def main() -> int:
         print()
 
     print("Index compliance:")
-    for index_path in EXPECTED_INDEXES:
-        issues = validate_expected_index(index_path, markdown_files)
+    for index_path in index_paths:
+        issues = validate_index_document(index_path, markdown_files)
         if issues:
             exit_code = 1
             print(f"  - {index_path}")

--- a/scripts/check_memory_bank_index.py
+++ b/scripts/check_memory_bank_index.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
-"""Audit markdown navigation integrity for the generic memory-bank template.
-
-The script intentionally focuses on `memory-bank/` and avoids downstream
-assumptions from example repositories.
-"""
+"""Audit markdown navigation integrity for a memory-bank-like documentation tree."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import posixpath
 import re
@@ -16,15 +13,78 @@ from collections import defaultdict, deque
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 IGNORED_DIRS = {".git", ".hg", ".svn", ".venv", "node_modules", "tmp", "log", "vendor"}
 
 DEFAULT_SCOPE_ROOT = "memory-bank"
+DEFAULT_MAX_DEPTH = 3
 
 FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---(?:\n|$)", re.DOTALL)
 BULLET_LINK_RE = re.compile(r"^\s*-\s+.*?(?<!\!)\[([^\]]+)\]\(([^)]+)\)")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit markdown navigation integrity for a memory-bank-like documentation tree."
+    )
+    parser.add_argument(
+        "--repo-root",
+        help="Filesystem path to the repository root. Defaults to the current directory when it contains the scope root.",
+    )
+    parser.add_argument(
+        "--scope-root",
+        default=DEFAULT_SCOPE_ROOT,
+        help="Repository-relative directory to audit. Default: %(default)s",
+    )
+    parser.add_argument(
+        "--entrypoint",
+        action="append",
+        default=[],
+        help=(
+            "Markdown document to use as a navigation entrypoint. Accepts repo-relative paths "
+            "and scope-relative paths. Repeat the option to pass several files."
+        ),
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=DEFAULT_MAX_DEPTH,
+        help="Maximum allowed navigation depth in link hops before the document becomes a warning. Default: %(default)s",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON report instead of text.",
+    )
+    args = parser.parse_args()
+    if args.max_depth < 0:
+        parser.error("--max-depth must be greater than or equal to 0")
+    return args
+
+
+def normalize_scope_root(scope_root: str) -> str:
+    normalized = posixpath.normpath(scope_root.strip())
+    if normalized in {"", "."}:
+        raise ValueError("--scope-root must point to a repository-relative directory")
+    return normalized.rstrip("/")
+
+
+def resolve_repo_root(repo_root_arg: str | None, scope_root: str) -> Path:
+    if repo_root_arg:
+        return Path(repo_root_arg).resolve()
+
+    candidates = [Path.cwd().resolve()]
+    if "__file__" in globals():
+        script_path = Path(__file__)
+        if str(script_path) not in {"", "<stdin>"}:
+            candidates.append(script_path.resolve().parents[1])
+
+    for candidate in candidates:
+        if (candidate / scope_root).exists():
+            return candidate
+
+    return candidates[0]
 
 
 def discover_markdown_files(repo_root: Path) -> dict[str, Path]:
@@ -44,41 +104,22 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="ignore")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Audit markdown navigation integrity for a memory-bank-like documentation tree."
-    )
-    parser.add_argument(
-        "--scope-root",
-        default=DEFAULT_SCOPE_ROOT,
-        help="Repository-relative directory to audit. Default: %(default)s",
-    )
-    parser.add_argument(
-        "--entrypoint",
-        action="append",
-        default=[],
-        help=(
-            "Repository-relative markdown document to use as reachability entrypoint. "
-            "Repeat the option to pass several files."
-        ),
-    )
-    return parser.parse_args()
-
-
-def scope_prefix(scope_root: str) -> str:
-    return f"{scope_root.rstrip('/')}/"
-
-
-def is_scoped_markdown(path: str, scoped_prefix: str) -> bool:
-    return path.startswith(scoped_prefix) and path.endswith(".md")
-
-
-def is_scope_readme(path: str, scoped_prefix: str) -> bool:
-    return is_scoped_markdown(path, scoped_prefix) and posixpath.basename(path) == "README.md"
-
-
 def strip_fenced_code_blocks(text: str) -> str:
     return FENCED_CODE_BLOCK_RE.sub("", text)
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+
+    frontmatter: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if not line or line.startswith((" ", "\t", "-")) or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        frontmatter[key.strip()] = value.strip().strip("\"'")
+    return frontmatter
 
 
 def normalize_internal_markdown_target(source_path: str, raw_url: str) -> str | None:
@@ -106,90 +147,150 @@ def normalize_internal_markdown_target(source_path: str, raw_url: str) -> str | 
     return resolved
 
 
-def extract_internal_markdown_links(source_path: str, text: str) -> list[tuple[str, str]]:
+def normalize_cli_document_path(raw_path: str) -> str | None:
+    path = raw_path.strip().strip("<>")
+    if not path:
+        return None
+
+    path = path.split("#", 1)[0].split("?", 1)[0].strip()
+    if not path:
+        return None
+
+    extension = posixpath.splitext(path)[1].lower()
+    if extension and extension != ".md":
+        return None
+
+    normalized = posixpath.normpath(path.lstrip("/"))
+    if normalized in {"", "."}:
+        return None
+
+    if not extension:
+        normalized = posixpath.join(normalized, "README.md")
+
+    return normalized
+
+
+def extract_internal_markdown_links(source_path: str, text: str) -> list[str]:
     stripped_text = strip_fenced_code_blocks(text)
-    links: list[tuple[str, str]] = []
+    links: list[str] = []
     for match in MARKDOWN_LINK_RE.finditer(stripped_text):
-        label = match.group(1).strip()
         target = normalize_internal_markdown_target(source_path, match.group(2))
         if target is None:
             continue
-        links.append((target, label))
+        links.append(target)
     return links
 
 
-def build_link_graph(
-    markdown_files: dict[str, Path], scoped_prefix: str
-) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
-    graph: dict[str, set[str]] = defaultdict(set)
-    broken_links: dict[str, set[str]] = defaultdict(set)
-    known_paths = set(markdown_files)
-
-    for source_path, full_path in markdown_files.items():
+def load_documents(repo_root: Path) -> dict[str, dict[str, object]]:
+    documents: dict[str, dict[str, object]] = {}
+    for relative_path, full_path in discover_markdown_files(repo_root).items():
         text = read_text(full_path)
-        for target, _label in extract_internal_markdown_links(source_path, text):
+        documents[relative_path] = {
+            "full_path": full_path,
+            "text": text,
+            "frontmatter": parse_frontmatter(text),
+        }
+    return documents
+
+
+def is_scoped_markdown(path: str, scope_root: str) -> bool:
+    return path.startswith(f"{scope_root}/") and path.endswith(".md")
+
+
+def is_scoped_readme(path: str, scope_root: str) -> bool:
+    return is_scoped_markdown(path, scope_root) and posixpath.basename(path) == "README.md"
+
+
+def resolve_entrypoint_path(entrypoint: str, scope_root: str, known_paths: set[str]) -> tuple[str | None, str]:
+    primary_candidate = normalize_cli_document_path(entrypoint)
+    if primary_candidate and primary_candidate in known_paths:
+        return primary_candidate, entrypoint
+
+    scoped_input = posixpath.join(scope_root, entrypoint.lstrip("/"))
+    scoped_candidate = normalize_cli_document_path(scoped_input)
+    if scoped_candidate and scoped_candidate in known_paths:
+        return scoped_candidate, entrypoint
+
+    fallback = primary_candidate or scoped_candidate or entrypoint
+    return None, fallback
+
+
+def derive_entrypoints(
+    documents: dict[str, dict[str, object]],
+    scope_root: str,
+    configured_entrypoints: list[str],
+) -> tuple[list[str], list[str]]:
+    known_paths = set(documents)
+    resolved: list[str] = []
+    missing: list[str] = []
+
+    if configured_entrypoints:
+        for entrypoint in configured_entrypoints:
+            resolved_path, missing_hint = resolve_entrypoint_path(entrypoint, scope_root, known_paths)
+            if resolved_path is None:
+                missing.append(missing_hint)
+                continue
+            if resolved_path not in resolved:
+                resolved.append(resolved_path)
+        return resolved, missing
+
+    default_entrypoint = f"{scope_root}/README.md"
+    if default_entrypoint in known_paths:
+        return [default_entrypoint], []
+
+    return [], [default_entrypoint]
+
+
+def build_link_graph(
+    documents: dict[str, dict[str, object]],
+    scope_root: str,
+) -> tuple[dict[str, set[str]], dict[str, set[str]], dict[str, set[str]]]:
+    outgoing: dict[str, set[str]] = defaultdict(set)
+    incoming_in_scope: dict[str, set[str]] = defaultdict(set)
+    broken_links: dict[str, set[str]] = defaultdict(set)
+    known_paths = set(documents)
+
+    for source_path, document in documents.items():
+        text = document["text"]
+        assert isinstance(text, str)
+        for target in extract_internal_markdown_links(source_path, text):
             if target in known_paths:
-                graph[source_path].add(target)
-            elif source_path.startswith(scoped_prefix):
+                outgoing[source_path].add(target)
+                if (
+                    source_path != target
+                    and is_scoped_markdown(source_path, scope_root)
+                    and is_scoped_markdown(target, scope_root)
+                ):
+                    incoming_in_scope[target].add(source_path)
+            elif is_scoped_markdown(source_path, scope_root):
                 broken_links[source_path].add(target)
 
-    return graph, broken_links
+    return outgoing, incoming_in_scope, broken_links
 
 
-def bfs_reachable(graph: dict[str, set[str]], start_files: tuple[str, ...]) -> set[str]:
-    visited: set[str] = set()
-    queue: deque[str] = deque()
-
-    for start_file in start_files:
-        visited.add(start_file)
-        queue.append(start_file)
-
-    while queue:
-        current = queue.popleft()
-        for target in sorted(graph.get(current, set())):
-            if target in visited:
-                continue
-            visited.add(target)
-            queue.append(target)
-
-    return visited
-
-
-def parse_frontmatter(text: str) -> dict[str, str]:
-    match = FRONTMATTER_RE.match(text)
-    if not match:
-        return {}
-
-    frontmatter: dict[str, str] = {}
-    for line in match.group(1).splitlines():
-        if not line or line.startswith((" ", "\t", "-")) or ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        frontmatter[key.strip()] = value.strip().strip("\"'")
-    return frontmatter
-
-
-def derive_start_files(markdown_files: dict[str, Path], scope_root: str, configured_entrypoints: list[str]) -> tuple[str, ...]:
-    if configured_entrypoints:
-        return tuple(configured_entrypoints)
-
-    fallback_root_index = f"{scope_root.rstrip('/')}/README.md"
-    if fallback_root_index in markdown_files:
-        return (fallback_root_index,)
-
-    return ()
-
-
-def derive_index_paths(markdown_files: dict[str, Path], scoped_prefix: str) -> list[str]:
+def derive_index_paths(documents: dict[str, dict[str, object]], scope_root: str) -> list[str]:
     index_paths: list[str] = []
-    for path, full_path in markdown_files.items():
-        if not is_scope_readme(path, scoped_prefix):
+    for path, document in documents.items():
+        if not is_scoped_markdown(path, scope_root):
             continue
-        frontmatter = parse_frontmatter(read_text(full_path))
+        frontmatter = document["frontmatter"]
+        assert isinstance(frontmatter, dict)
+        if frontmatter.get("doc_function") == "index":
+            index_paths.append(path)
+    return sorted(index_paths)
+
+
+def derive_expected_readme_indices(documents: dict[str, dict[str, object]], scope_root: str) -> list[str]:
+    readmes: list[str] = []
+    for path, document in documents.items():
+        if not is_scoped_readme(path, scope_root):
+            continue
+        frontmatter = document["frontmatter"]
+        assert isinstance(frontmatter, dict)
         if frontmatter.get("doc_function") == "template":
             continue
-        index_paths.append(path)
-    return sorted(index_paths)
+        readmes.append(path)
+    return sorted(readmes)
 
 
 def annotation_text_for_child_links(index_path: str, text: str) -> list[tuple[str, str]]:
@@ -210,12 +311,8 @@ def annotation_text_for_child_links(index_path: str, text: str) -> list[tuple[st
             index_line += 1
             continue
 
-        if section_prefix:
-            child_prefix = f"{section_prefix}/"
-            if not target.startswith(child_prefix):
-                index_line += 1
-                continue
-        elif "/" in target:
+        child_prefix = f"{section_prefix}/"
+        if section_prefix and not target.startswith(child_prefix):
             index_line += 1
             continue
 
@@ -241,14 +338,17 @@ def annotation_text_for_child_links(index_path: str, text: str) -> list[tuple[st
     return annotations
 
 
-def validate_index_document(index_path: str, markdown_files: dict[str, Path]) -> list[str]:
-    issues: list[str] = []
-    full_path = markdown_files.get(index_path)
-    if full_path is None:
+def validate_index_document(index_path: str, documents: dict[str, dict[str, object]]) -> list[str]:
+    document = documents.get(index_path)
+    if document is None:
         return ["missing expected index file"]
 
-    text = read_text(full_path)
-    frontmatter = parse_frontmatter(text)
+    text = document["text"]
+    frontmatter = document["frontmatter"]
+    assert isinstance(text, str)
+    assert isinstance(frontmatter, dict)
+
+    issues: list[str] = []
     if not frontmatter:
         issues.append("missing YAML frontmatter")
     if frontmatter.get("purpose", "") == "":
@@ -272,75 +372,343 @@ def validate_index_document(index_path: str, markdown_files: dict[str, Path]) ->
     return issues
 
 
-def main() -> int:
-    args = parse_args()
-    markdown_files = discover_markdown_files(REPO_ROOT)
-    scoped_prefix = scope_prefix(args.scope_root)
-    scoped_markdown_paths = sorted(path for path in markdown_files if is_scoped_markdown(path, scoped_prefix))
-    graph, broken_links = build_link_graph(markdown_files, scoped_prefix)
-    start_files = derive_start_files(markdown_files, args.scope_root, args.entrypoint)
-    index_paths = derive_index_paths(markdown_files, scoped_prefix)
+def expected_parent_index(path: str, index_paths: set[str], scope_root: str) -> str | None:
+    if not is_scoped_markdown(path, scope_root):
+        return None
 
-    if not start_files:
-        print("Navigation audit failed: no scoped entrypoints were discovered.")
-        return 1
+    current_dir = posixpath.dirname(path)
+    if posixpath.basename(path) == "README.md":
+        current_dir = posixpath.dirname(current_dir)
 
-    missing_start_files = [start_file for start_file in start_files if start_file not in markdown_files]
-    if missing_start_files:
-        print("Navigation audit failed: configured entrypoints are missing.")
-        for start_file in missing_start_files:
-            print(f"  - {start_file}")
-        return 1
+    while current_dir and current_dir != ".":
+        candidate = posixpath.join(current_dir, "README.md")
+        if candidate in index_paths and candidate != path:
+            return candidate
+        parent_dir = posixpath.dirname(current_dir)
+        if parent_dir == current_dir:
+            break
+        current_dir = parent_dir
 
-    reachable = bfs_reachable(graph, start_files)
-    unreachable = sorted(path for path in scoped_markdown_paths if path not in reachable)
+    return None
 
-    exit_code = 0
 
-    print("Memory-bank navigation audit")
-    print(f"Repo root: {REPO_ROOT}")
-    print(f"Scope: {scoped_prefix}")
-    print(f"Start files: {', '.join(start_files)}")
-    print(f"Markdown files in scope: {len(scoped_markdown_paths)}")
+def build_navigation_reachability(
+    outgoing: dict[str, set[str]],
+    navigation_nodes: set[str],
+    entrypoints: list[str],
+) -> dict[str, dict[str, object]]:
+    reachable: dict[str, dict[str, object]] = {}
+    navigation_depths: dict[str, int] = {}
+    queue: deque[str] = deque()
+
+    for entrypoint in entrypoints:
+        reachable[entrypoint] = {"depth": 0, "route": [entrypoint]}
+        navigation_depths[entrypoint] = 0
+        queue.append(entrypoint)
+
+    while queue:
+        current = queue.popleft()
+        current_info = reachable[current]
+        current_depth = navigation_depths[current]
+        current_route = current_info["route"]
+        assert isinstance(current_route, list)
+
+        for target in sorted(outgoing.get(current, set())):
+            candidate_depth = current_depth + 1
+            candidate_route = current_route + [target]
+            best = reachable.get(target)
+            if best is None or candidate_depth < best["depth"]:
+                reachable[target] = {"depth": candidate_depth, "route": candidate_route}
+            if target in navigation_nodes:
+                best_depth = navigation_depths.get(target)
+                if best_depth is None or candidate_depth < best_depth:
+                    navigation_depths[target] = candidate_depth
+                    queue.append(target)
+
+    return reachable
+
+
+def flatten_broken_links(broken_links: dict[str, set[str]]) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for source_path in sorted(broken_links):
+        for target in sorted(broken_links[source_path]):
+            items.append({"source": source_path, "target": target})
+    return items
+
+
+def build_report(
+    repo_root: Path,
+    scope_root: str,
+    entrypoints: list[str],
+    missing_entrypoints: list[str],
+    max_depth: int,
+    documents: dict[str, dict[str, object]],
+) -> dict[str, object]:
+    scoped_markdown_paths = sorted(path for path in documents if is_scoped_markdown(path, scope_root))
+    index_paths = derive_index_paths(documents, scope_root)
+    expected_readme_indices = derive_expected_readme_indices(documents, scope_root)
+    outgoing, incoming_in_scope, broken_links = build_link_graph(documents, scope_root)
+
+    report: dict[str, object] = {
+        "format_version": 1,
+        "repo_root": str(repo_root),
+        "scope_root": scope_root,
+        "entrypoints": entrypoints,
+        "missing_entrypoints": missing_entrypoints,
+        "max_depth": max_depth,
+        "stats": {
+            "markdown_files_in_scope": len(scoped_markdown_paths),
+            "index_documents_in_scope": len(index_paths),
+        },
+        "errors": {
+            "config": [],
+            "broken_links": flatten_broken_links(broken_links),
+            "orphans": [],
+            "unreachable": [],
+            "index_contract": [],
+        },
+        "warnings": {
+            "deep_reachable": [],
+        },
+    }
+
+    config_errors = report["errors"]["config"]
+    assert isinstance(config_errors, list)
+    if missing_entrypoints:
+        config_errors.append(
+            {
+                "message": "Configured entrypoints are missing.",
+                "paths": missing_entrypoints,
+            }
+        )
+    if not scoped_markdown_paths:
+        config_errors.append(
+            {
+                "message": "Scope contains no markdown files.",
+                "paths": [scope_root],
+            }
+        )
+    if not entrypoints:
+        config_errors.append(
+            {
+                "message": "No valid entrypoints were resolved.",
+                "paths": missing_entrypoints or [f"{scope_root}/README.md"],
+            }
+        )
+
+    index_paths_set = set(index_paths)
+    entrypoint_set = set(entrypoints)
+
+    if entrypoints and scoped_markdown_paths:
+        navigation_nodes = set(index_paths) | entrypoint_set
+        reachable = build_navigation_reachability(outgoing, navigation_nodes, entrypoints)
+
+        for path in scoped_markdown_paths:
+            inbound_sources = sorted(incoming_in_scope.get(path, set()))
+            parent_index = expected_parent_index(path, index_paths_set, scope_root)
+            if path not in entrypoint_set and not inbound_sources:
+                report["errors"]["orphans"].append(
+                    {
+                        "path": path,
+                        "expected_parent_index": parent_index,
+                        "inbound_links": inbound_sources,
+                    }
+                )
+
+            reachability = reachable.get(path)
+            if reachability is None:
+                report["errors"]["unreachable"].append(
+                    {
+                        "path": path,
+                        "expected_parent_index": parent_index,
+                        "inbound_links": inbound_sources,
+                    }
+                )
+                continue
+
+            depth = reachability["depth"]
+            route = reachability["route"]
+            assert isinstance(depth, int)
+            assert isinstance(route, list)
+            if depth > max_depth:
+                report["warnings"]["deep_reachable"].append(
+                    {
+                        "path": path,
+                        "depth": depth,
+                        "max_depth": max_depth,
+                        "expected_parent_index": parent_index,
+                        "route": route,
+                    }
+                )
+
+    for index_path in expected_readme_indices:
+        issues = validate_index_document(index_path, documents)
+        if not issues:
+            continue
+        report["errors"]["index_contract"].append(
+            {
+                "path": index_path,
+                "issues": issues,
+                "expected_parent_index": expected_parent_index(index_path, index_paths_set, scope_root),
+            }
+        )
+
+    warnings = report["warnings"]["deep_reachable"]
+    assert isinstance(warnings, list)
+    warnings.sort(key=lambda item: (item["depth"], item["path"]))
+
+    stats = report["stats"]
+    assert isinstance(stats, dict)
+    errors = report["errors"]
+    assert isinstance(errors, dict)
+    stats.update(
+        {
+            "broken_link_count": len(errors["broken_links"]),
+            "orphan_count": len(errors["orphans"]),
+            "unreachable_count": len(errors["unreachable"]),
+            "index_contract_issue_count": len(errors["index_contract"]),
+            "deep_reachable_warning_count": len(warnings),
+            "entrypoint_count": len(entrypoints),
+        }
+    )
+
+    has_errors = any(bool(errors[key]) for key in ("config", "broken_links", "orphans", "unreachable", "index_contract"))
+    report["exit_code"] = 1 if has_errors else 0
+    return report
+
+
+def format_route(route: list[str]) -> str:
+    return " -> ".join(route)
+
+
+def print_text_report(report: dict[str, object]) -> None:
+    print("Memory-bank link audit")
+    print(f"Repo root: {report['repo_root']}")
+    print(f"Scope root: {report['scope_root']}")
+    print(f"Entrypoints: {', '.join(report['entrypoints']) or '(none)'}")
+    print(f"Navigation depth threshold: {report['max_depth']}")
+
+    stats = report["stats"]
+    errors = report["errors"]
+    warnings = report["warnings"]
+    assert isinstance(stats, dict)
+    assert isinstance(errors, dict)
+    assert isinstance(warnings, dict)
+
+    print(f"Markdown files in scope: {stats['markdown_files_in_scope']}")
+    print(f"Index documents in scope: {stats['index_documents_in_scope']}")
     print()
 
-    scoped_broken_links = {
-        source_path: sorted(targets)
-        for source_path, targets in broken_links.items()
-        if source_path.startswith(scoped_prefix)
-    }
-    if scoped_broken_links:
-        exit_code = 1
+    config_errors = errors["config"]
+    assert isinstance(config_errors, list)
+    if config_errors:
+        print("Configuration errors:")
+        for item in config_errors:
+            print(f"  - {item['message']}")
+            for path in item["paths"]:
+                print(f"    * {path}")
+        print()
+
+    broken_links = errors["broken_links"]
+    assert isinstance(broken_links, list)
+    if broken_links:
         print("Broken internal markdown links:")
-        for source_path in sorted(scoped_broken_links):
-            for target in scoped_broken_links[source_path]:
-                print(f"  - {source_path} -> {target}")
+        for item in broken_links:
+            print(f"  - {item['source']} -> {item['target']}")
         print()
     else:
         print("OK: no broken internal markdown links in scope.")
         print()
 
-    if unreachable:
-        exit_code = 1
-        print("Unreachable markdown files in scope:")
-        for path in unreachable:
-            print(f"  - {path}")
+    orphans = errors["orphans"]
+    assert isinstance(orphans, list)
+    if orphans:
+        print("Orphan markdown files in scope:")
+        for item in orphans:
+            print(f"  - {item['path']}")
+            print(f"    expected_parent_index: {item['expected_parent_index'] or '(none)'}")
         print()
     else:
-        print("OK: all scoped markdown files are reachable from the configured start files.")
+        print("OK: no orphan markdown files in scope.")
         print()
 
-    print("Index compliance:")
-    for index_path in index_paths:
-        issues = validate_index_document(index_path, markdown_files)
-        if issues:
-            exit_code = 1
-            print(f"  - {index_path}")
-            for issue in issues:
-                print(f"    * {issue}")
-            continue
-        print(f"  - {index_path}: OK")
+    unreachable = errors["unreachable"]
+    assert isinstance(unreachable, list)
+    if unreachable:
+        print("Markdown files missing from index navigation:")
+        for item in unreachable:
+            print(f"  - {item['path']}")
+            print(f"    expected_parent_index: {item['expected_parent_index'] or '(none)'}")
+            inbound_links = item["inbound_links"]
+            if inbound_links:
+                print(f"    inbound_links: {', '.join(inbound_links)}")
+        print()
+    else:
+        print("OK: all scoped markdown files are reachable from the configured entrypoints via index navigation.")
+        print()
 
+    deep_reachable = warnings["deep_reachable"]
+    assert isinstance(deep_reachable, list)
+    if deep_reachable:
+        print("Warnings: documents reachable only deeper than the configured threshold:")
+        for item in deep_reachable:
+            print(f"  - {item['path']}")
+            print(f"    depth: {item['depth']}")
+            print(f"    expected_parent_index: {item['expected_parent_index'] or '(none)'}")
+            print(f"    route: {format_route(item['route'])}")
+        print()
+    else:
+        print("OK: no documents are reachable only deeper than the configured threshold.")
+        print()
+
+    index_contract = errors["index_contract"]
+    assert isinstance(index_contract, list)
+    print("Index compliance:")
+    if index_contract:
+        for item in index_contract:
+            print(f"  - {item['path']}")
+            for issue in item["issues"]:
+                print(f"    * {issue}")
+        print()
+    else:
+        print("  - OK")
+        print()
+
+    exit_code = report["exit_code"]
+    assert isinstance(exit_code, int)
+    result = "FAIL" if exit_code else "OK"
+    print(f"Result: {result}")
+    print("Machine-readable output: re-run with --json for a structured report suitable for auto-indexing.")
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        scope_root = normalize_scope_root(args.scope_root)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    repo_root = resolve_repo_root(args.repo_root, scope_root)
+    documents = load_documents(repo_root)
+    entrypoints, missing_entrypoints = derive_entrypoints(documents, scope_root, args.entrypoint)
+    report = build_report(
+        repo_root=repo_root,
+        scope_root=scope_root,
+        entrypoints=entrypoints,
+        missing_entrypoints=missing_entrypoints,
+        max_depth=args.max_depth,
+        documents=documents,
+    )
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print_text_report(report)
+
+    exit_code = report["exit_code"]
+    assert isinstance(exit_code, int)
     return exit_code
 
 


### PR DESCRIPTION
## What changed

- added `scripts/check_memory_bank_index.py` to audit markdown navigation integrity inside `memory-bank/`
- made the audit configurable via `--scope-root`, repeatable `--entrypoint`, `--max-depth`, `--repo-root`, and `--json`
- separated hard failures from depth-only warnings so deeply reachable docs are reported without failing the audit
- documented local usage, network one-liner, local install/copy flow, and platform notes in `README.md`
- added the new check to repository guidance in `AGENTS.md`

## Why

The template relies on README-based navigation and relative links, but the repo had no lightweight automated check for:
- broken internal markdown links
- orphaned docs inside `memory-bank/`
- documents that dropped out of index navigation
- malformed expected `README.md` index documents

This adds a reusable local audit that can catch navigation drift before PRs land.

## Impact

- contributors can run a single command to validate `memory-bank/` navigation
- downstream repos can reuse the same script and point it at a different repo root or scope
- the report is machine-readable enough for follow-up auto-indexing workflows

## Validation

- `rg --files memory-bank examples`
- `python3 scripts/check_memory_bank_index.py`
- `python3 scripts/check_memory_bank_index.py --json`
- `python3 scripts/check_memory_bank_index.py --max-depth 2`
- `python3 -m py_compile scripts/check_memory_bank_index.py`
- `git diff --check`
- `rg -n "Merchantly|CloudPayments|kiiiosk|Bugsnag" memory-bank`

Closes #3
