### PR TITLE
Add process templates

### DIFF
--- a/memory-bank/flows/templates/README.md
+++ b/memory-bank/flows/templates/README.md
@@ -13,6 +13,7 @@ derived_from:
   - feature/large.md
   - adr/ADR-XXX.md
   - prompt/PROMPT-XXX.md
+  - process/README.md
 status: active
 audience: humans_and_agents
 ---
@@ -29,3 +30,4 @@ audience: humans_and_agents
 - [FT-XXX: Implementation Plan](feature/implementation-plan.md) — шаблон derived execution-плана. Отвечает на вопрос: как оформить sequencing и checkpoints.
 - [ADR-XXX: Short Decision Name](adr/ADR-XXX.md) — шаблон ADR. Отвечает на вопрос: как зафиксировать архитектурное решение.
 - [PROMPT-XXX: Reusable Prompt Name](prompt/PROMPT-XXX.md) — шаблон reusable prompt-документа. Отвечает на вопрос: как сохранить исходную формулировку в frontmatter и улучшенный prompt в copyable body-блоке.
+- [PROC-XXX: Process Documentation Index](process/README.md) — шаблон индекса процесс-документов. Отвечает на вопрос: как собрать routing-layer для reusable process cards, session handoff и lifecycle protocol.

--- a/memory-bank/flows/templates/process/README.md
+++ b/memory-bank/flows/templates/process/README.md
@@ -1,0 +1,69 @@
+---
+title: "PROC-XXX: Process Documentation Index"
+doc_kind: process
+doc_function: template
+purpose: Governed wrapper-шаблон для `processes/README.md`. Читать, чтобы собрать каталог процесс-документов проекта без смешения wrapper-метаданных и frontmatter будущего index-документа.
+derived_from:
+  - ../../dna/governance.md
+  - ../../dna/frontmatter.md
+  - ../../workflows.md
+status: active
+audience: humans_and_agents
+template_for: process
+template_target_path: ../../../processes/README.md
+canonical_for:
+  - process_template_index
+---
+
+# PROC-XXX: Process Documentation Index
+
+Этот файл описывает wrapper-template. Инстанцируемый `processes/README.md` живет ниже как embedded contract и копируется без wrapper frontmatter и history.
+
+## Wrapper Notes
+
+Каталог `processes/` нужен для reusable process-documents, которые живут между ad-hoc заметкой и feature package. Он помогает держать процесс отдельно от продуктового scope: сюда попадают повторяемые workflows, session handoff, lifecycle protocols и другие управляемые последовательности действий.
+
+Этот index-шаблон предназначен для навигации по трехуровневой process-линейке:
+
+- компактная карточка процесса;
+- session handoff для продолжения работы между сессиями;
+- lifecycle protocol для длинных delivery-процессов с gates и verification.
+
+Если проекту достаточно одного процесса, всё равно оставь `README.md` как routing-layer: он фиксирует, какие process-documents существуют, что они покрывают и когда их открывать.
+
+## Instantiated Frontmatter
+
+```yaml
+title: "Process Documentation Index"
+doc_kind: process
+doc_function: index
+purpose: "Навигация по reusable process-документам проекта и выбор правильного шаблона для конкретного workflow."
+derived_from:
+  - ../flows/workflows.md
+status: active
+audience: humans_and_agents
+```
+
+## Instantiated Body
+
+```markdown
+# Process Documentation Index
+
+## О каталоге
+
+Каталог `processes/` хранит reusable процесс-документы: компактные карточки процессов, session handoff для продолжения работы между сессиями и lifecycle protocol для сложных delivery-flow с проверками и gates.
+
+## Аннотированный индекс
+
+- [`process-card.md`](process-card.md)
+  Читать, когда нужен компактный, повторяемый процесс без большой state machine.
+  Отвечает на вопрос: как зафиксировать короткий workflow, который можно выполнять по одной карточке.
+
+- [`session-handoff.md`](session-handoff.md)
+  Читать, когда работа переносится между сессиями или компьютерами и нужно сохранить current state, assumptions, risks и next checks.
+  Отвечает на вопрос: как безопасно продолжить уже начатый процесс без потери контекста.
+
+- [`lifecycle-protocol.md`](lifecycle-protocol.md)
+  Читать, когда процесс состоит из фаз, human gates, verification и rollback и должен переживать длинный delivery-cycle.
+  Отвечает на вопрос: как управлять полным жизненным циклом изменения от старта до handoff или closure.
+```

--- a/memory-bank/flows/templates/process/lifecycle-protocol.md
+++ b/memory-bank/flows/templates/process/lifecycle-protocol.md
@@ -1,0 +1,127 @@
+---
+title: "PROC-XXX: Lifecycle Protocol"
+doc_kind: process
+doc_function: template
+purpose: Governed wrapper-шаблон для полного lifecycle protocol. Читать, когда процесс проходит через фазы, gates, verification и rollback.
+derived_from:
+  - ../../dna/governance.md
+  - ../../dna/frontmatter.md
+  - ../../flows/workflows.md
+  - ../../flows/feature-flow.md
+status: active
+audience: humans_and_agents
+template_for: process
+template_target_path: ../../../processes/PROCESS-XXX-lifecycle-protocol.md
+canonical_for:
+  - process_template_lifecycle_protocol
+---
+
+# PROC-XXX: Lifecycle Protocol
+
+Этот файл описывает wrapper-template. Инстанцируемый lifecycle protocol живет ниже как embedded contract и копируется без wrapper frontmatter и history.
+
+## Wrapper Notes
+
+Это heavyweight-вариант для длинных изменений и управляемых delivery-processes: здесь процесс разбивается на фазы, а каждая фаза имеет свои exit criteria, checks, evidence и human gates.
+
+Используй этот шаблон, когда:
+
+- есть несколько фаз работы;
+- нужен явный owner и approval flow;
+- важно разделить implementation, verification и handoff;
+- требуется rollback или stop conditions;
+- процесс должен переживать не одну сессию.
+
+Этот шаблон ближе всего к `brief → spec → plan → implement → verify → ship`, а не к короткой рутине.
+
+## Instantiated Frontmatter
+
+```yaml
+title: "PROC-XXX: Lifecycle Protocol"
+doc_kind: process
+doc_function: canonical
+purpose: "Описывает полный процесс изменения с фазами, gates, verification и rollback."
+derived_from:
+  - ../README.md
+  - ../../feature-flow.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - product_strategy
+  - domain_model
+```
+
+## Instantiated Body
+
+```markdown
+# PROC-XXX: Lifecycle Protocol
+
+## Goal
+
+Какой результат должен быть достигнут и почему этот процесс вообще нужен.
+
+## Scope
+
+### In Scope
+
+- Что входит в этот lifecycle.
+
+### Out Of Scope
+
+- Что исключено из процесса.
+
+## Baseline Facts
+
+- Что уже известно.
+- На каких проверенных фактах держится старт процесса.
+
+## Phases
+
+### Phase 1: Prepare
+
+- Подготовить входные данные.
+- Уточнить неизвестности.
+- Зафиксировать стартовый state.
+
+### Phase 2: Execute
+
+- Выполнить основную работу.
+- Двигаться по step-by-step plan.
+
+### Phase 3: Verify
+
+- Прогнать проверки.
+- Зафиксировать evidence.
+
+### Phase 4: Hand Off or Close
+
+- Передать следующий state или закрыть процесс.
+
+## Human Gates
+
+### H1
+
+- Что можно делать только после явного одобрения.
+
+### H2
+
+- Что требует commit point или acceptance.
+
+### H3
+
+- Что является destructive / irreversible action.
+
+## Verification
+
+- Какие проверки обязательны.
+- Какой evidence должен остаться.
+
+## Rollback
+
+- Что делать, если процесс нужно откатить.
+- Где проходит точка невозврата.
+
+## Stop Conditions
+
+- Что заставляет немедленно остановиться.
+```

--- a/memory-bank/flows/templates/process/process-card.md
+++ b/memory-bank/flows/templates/process/process-card.md
@@ -1,0 +1,94 @@
+---
+title: "PROC-XXX: Compact Process Card"
+doc_kind: process
+doc_function: template
+purpose: Governed wrapper-шаблон для компактной process-card. Читать, чтобы зафиксировать короткий reusable workflow без тяжёлого lifecycle-каркаса.
+derived_from:
+  - ../../dna/governance.md
+  - ../../dna/frontmatter.md
+  - ../../workflows.md
+status: active
+audience: humans_and_agents
+template_for: process
+template_target_path: ../../../processes/PROCESS-XXX-process-card.md
+canonical_for:
+  - process_template_card
+---
+
+# PROC-XXX: Compact Process Card
+
+Этот файл описывает wrapper-template. Инстанцируемый process-card живет ниже как embedded contract и копируется без wrapper frontmatter и history.
+
+## Wrapper Notes
+
+Этот вариант нужен, когда процесс повторяется часто, но не требует полноценного protocol: один trigger, понятный owner, короткий список шагов и ясные exit criteria.
+
+Хороший кандидат для этого шаблона:
+
+- короткий ручной workflow;
+- операционная рутина;
+- повторяемый internal step без сложных gates;
+- процесс, который удобно описывать на одной странице.
+
+Если процесс начинает требовать handoff state, approval gates, rollback или явные verification phase, это сигнал перейти к `session-handoff.md` или `lifecycle-protocol.md`.
+
+## Instantiated Frontmatter
+
+```yaml
+title: "PROC-XXX: Compact Process Card"
+doc_kind: process
+doc_function: canonical
+purpose: "Фиксирует короткий reusable workflow с одним trigger, owner, шагами и exit criteria."
+derived_from:
+  - ../README.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - full_delivery_lifecycle
+  - approval_gates
+  - rollback_protocol
+```
+
+## Instantiated Body
+
+```markdown
+# PROC-XXX: Compact Process Card
+
+## Purpose
+
+Коротко опиши, зачем этот процесс существует и какой результат он должен стабильно давать.
+
+## Trigger
+
+- Что запускает процесс.
+- Кто его инициирует.
+- Какие входные данные нужны перед стартом.
+
+## Scope
+
+### In Scope
+
+- Что этот workflow делает.
+
+### Out Of Scope
+
+- Что он сознательно не покрывает.
+
+## Steps
+
+1. Шаг 1.
+2. Шаг 2.
+3. Шаг 3.
+
+## Exit Criteria
+
+- Что должно быть истинно, чтобы процесс считался завершенным.
+
+## Evidence
+
+- Какой артефакт, лог, ссылка или статус подтверждает выполнение.
+
+## Escalation
+
+- Когда процесс нужно остановить и поднять к человеку.
+```

--- a/memory-bank/flows/templates/process/session-handoff.md
+++ b/memory-bank/flows/templates/process/session-handoff.md
@@ -1,0 +1,101 @@
+---
+title: "PROC-XXX: Session Handoff"
+doc_kind: process
+doc_function: template
+purpose: Governed wrapper-шаблон для session handoff. Читать, чтобы сохранять состояние процесса между сессиями без потери assumptions, risks и next checks.
+derived_from:
+  - ../../dna/governance.md
+  - ../../dna/frontmatter.md
+  - ../../workflows.md
+status: active
+audience: humans_and_agents
+template_for: process
+template_target_path: ../../../processes/PROCESS-XXX-session-handoff.md
+canonical_for:
+  - process_template_session_handoff
+---
+
+# PROC-XXX: Session Handoff
+
+Этот файл описывает wrapper-template. Инстанцируемый session handoff живет ниже как embedded contract и копируется без wrapper frontmatter и history.
+
+## Wrapper Notes
+
+Это шаблон для случаев, когда работа прерывается и должна быть продолжена позже: новая сессия, другой компьютер, другой оператор или long-running workflow с паузами между шагами.
+
+Ключевая идея: в handoff попадают не все детали подряд, а только то, что реально нужно для безопасного продолжения.
+
+Обязательно фиксируй:
+
+- текущий выполненный шаг;
+- текущий шаг, на котором остановились;
+- рабочие допущения;
+- открытые риски;
+- ближайшие проверки;
+- следующую конкретную action.
+
+Если процесс начинает требовать формальных gates, rollback и multi-phase verification, используй `lifecycle-protocol.md`.
+
+## Instantiated Frontmatter
+
+```yaml
+title: "PROC-XXX: Session Handoff"
+doc_kind: process
+doc_function: canonical
+purpose: "Фиксирует состояние незавершенного процесса так, чтобы следующая сессия могла продолжить работу без потери контекста."
+derived_from:
+  - ../README.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - long_term_project_policy
+  - product_scope
+```
+
+## Instantiated Body
+
+```markdown
+# PROC-XXX: Session Handoff
+
+## Current State
+
+- Что уже сделано.
+- Где именно остановились.
+- Какой артефакт является актуальным.
+
+## Completed
+
+- Список завершенных шагов или проверок.
+
+## Current Step
+
+- Один конкретный шаг, который выполняется сейчас или должен быть выполнен следующим.
+
+## Assumptions
+
+- Какие допущения были приняты по ходу работы.
+
+## Open Risks
+
+- Какие риски еще не сняты.
+
+## Next Checks
+
+- Что нужно проверить перед продолжением.
+
+## Evidence Log
+
+| Time | Fact / action | Evidence |
+|---|---|---|
+| `<yyyy-mm-dd hh:mm>` | `<fact-or-action>` | `<source-or-command-output-ref>` |
+
+## Next Action
+
+- Кто действует.
+- Что именно он делает.
+- Когда останавливаемся.
+
+## Stop Conditions
+
+- Когда нельзя продолжать без человека.
+```


### PR DESCRIPTION
## What changed
- Added a new `memory-bank/flows/templates/process/` family with three governed wrapper templates:
  - compact process card
  - session handoff
  - lifecycle protocol
- Added a process templates index to route readers to the right variant.
- Linked the new process family from the shared templates index.

## Why
The repository already had feature, ADR, and prompt templates, but no reusable process-layer templates for short workflows, session continuity, or long-running lifecycle protocols.

## Impact
- Gives downstream repos a ready-made pattern for process documentation.
- Separates lightweight routines from session handoff and full delivery protocols.
- Keeps process routing discoverable from `memory-bank/flows/templates/README.md`.

## Validation
- `git diff --check`
