### PR TITLE
[codex] add generic epic flow

### DIFF
--- a/memory-bank/README.md
+++ b/memory-bank/README.md
@@ -24,6 +24,9 @@ audience: humans_and_agents
 - [`prd/README.md`](prd/README.md)
   Читать, когда нужно: описать продуктовую инициативу между общим product context и downstream feature packages.
 
+- [`epics/README.md`](epics/README.md)
+  Читать, когда нужно: вести крупную инициативу через roadmap, decision log, risks и набор связанных delivery subissues.
+
 - [`use-cases/README.md`](use-cases/README.md)
   Читать, когда нужно: зарегистрировать устойчивый пользовательский или операционный сценарий проекта.
 
@@ -40,7 +43,7 @@ audience: humans_and_agents
   Читать, когда нужно: проверить SSoT rules, frontmatter contract и governance-правила документации.
 
 - [`flows/README.md`](flows/README.md)
-  Читать, когда нужно: создать feature package, провести фичу по lifecycle gates или использовать шаблон.
+  Читать, когда нужно: создать epic/feature package, провести инициативу по lifecycle gates или использовать шаблон.
 
 - [`adr/README.md`](adr/README.md)
   Читать, когда нужно: найти или завести Architecture Decision Record.

--- a/memory-bank/epics/README.md
+++ b/memory-bank/epics/README.md
@@ -1,0 +1,43 @@
+---
+title: Epics Index
+doc_kind: epic
+doc_function: index
+purpose: "Навигация по instantiated epic packages. Читать, когда инициатива крупнее одной feature и должна исполняться через roadmap и набор связанных subissues."
+derived_from:
+  - ../dna/governance.md
+  - ../flows/epic-flow.md
+  - ../flows/feature-flow.md
+status: active
+audience: humans_and_agents
+---
+
+# Epics Index
+
+Каталог `memory-bank/epics/` хранит instantiated epic packages вида `EP-XXX/`.
+
+## Rules
+
+- Epic описывает крупное проектное изменение, которое нельзя безопасно реализовать одной delivery-feature.
+- Epic владеет intent, roadmap, декомпозицией, decision log, рисками и реестром subissues.
+- Epic не владеет code-level execution: реализация идёт через отдельные `memory-bank/features/FT-<issue>/` packages.
+- Каждый delivery subissue должен ссылаться на соответствующие epic artifacts и project-level `UC-*`, если меняет устойчивый сценарий.
+- Правила создания и ведения epic packages живут в [`../flows/epic-flow.md`](../flows/epic-flow.md).
+
+## Naming
+
+- Базовый формат: `EP-XXX/`
+- Вместо `XXX` используй стабильный идентификатор инициативы: issue id, project id или другое устойчивое имя
+- Один epic = одна крупная программа/инициатива с несколькими delivery-slices
+
+## Package Layers
+
+| Layer | Files | Purpose |
+| --- | --- | --- |
+| Intent | `charter.md`, source refs, stakeholder channels | Зачем существует epic, что входит/не входит, какие facts уже подтверждены |
+| Governance | `roadmap.md`, `decision-log.md`, `risks.md`, `subissues.md` | Как исполнять epic, какие решения приняты, какие риски и subissues управляются |
+| Knowledge | `design.md`, `specs/**`, `diagrams/**`, linked `UC-*` | Нормализованные требования, bounded contexts, сценарии, контракты и audit trail |
+| Execution Handoff | future `memory-bank/features/FT-<issue>/` | Конкретные code changes, тесты, rollout/backout для одного approved delivery issue |
+
+## Instantiated Epics
+
+В шаблонном репозитории этот каталог может быть пустым. Это нормально.

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -18,6 +18,7 @@ audience: humans_and_agents
 
 - Каждый package создается по правилам из [`../flows/feature-flow.md`](../flows/feature-flow.md).
 - Для bootstrap используй шаблоны из [`../flows/templates/feature/`](../flows/templates/feature/).
+- Если работа требует roadmap, risk register и нескольких delivery subissues, сначала создай или обнови epic package в [`../epics/README.md`](../epics/README.md).
 - По умолчанию feature ссылается на общий product context из [`../product/context.md`](../product/context.md), а при изменении предметных правил также на соответствующие документы из [`../domain/README.md`](../domain/README.md).
 - Если feature реализует или существенно меняет устойчивый сценарий проекта, она должна ссылаться на соответствующий `UC-*` из [`../use-cases/README.md`](../use-cases/README.md).
 - В шаблонном репозитории этот каталог может быть пустым. Это нормально.

--- a/memory-bank/flows/README.md
+++ b/memory-bank/flows/README.md
@@ -2,9 +2,10 @@
 title: Flows And Templates Index
 doc_kind: governance
 doc_function: index
-purpose: Навигация по lifecycle flows и governed-шаблонам. Читать при создании feature package, переводе feature между стадиями или инстанцировании нового governed-документа.
+purpose: Навигация по lifecycle flows и governed-шаблонам. Читать при создании epic или feature package, переводе инициативы между стадиями или инстанцировании нового governed-документа.
 derived_from:
   - ../dna/governance.md
+  - epic-flow.md
   - feature-flow.md
   - workflows.md
   - templates/README.md
@@ -17,5 +18,6 @@ audience: humans_and_agents
 Каталог `memory-bank/flows/` содержит reusable process-layer для шаблона: lifecycle rules, taxonomy стабильных идентификаторов и governed templates.
 
 - [Task Workflows](workflows.md) — маршрутизация задач по типам, базовый цикл разработки и градиент автономии.
+- [Epic Flow](epic-flow.md) — lifecycle крупных инициатив, roadmap, decision log, risks и handoff в feature packages.
 - [Feature Flow](feature-flow.md) — lifecycle от draft до closure, gates и стабильные ID (`REQ-*`, `CHK-*`, `STEP-*`).
-- [Templates Index](templates/README.md) — эталонные шаблоны governed-документов, включая PRD, use case, feature и ADR.
+- [Templates Index](templates/README.md) — эталонные шаблоны governed-документов, включая PRD, use case, epic, feature и ADR.

--- a/memory-bank/flows/epic-flow.md
+++ b/memory-bank/flows/epic-flow.md
@@ -1,0 +1,136 @@
+---
+title: Epic Flow
+doc_kind: governance
+doc_function: canonical
+purpose: "Определяет lifecycle и качество epic-документации: charter, roadmap, decision log, risks, subissues и handoff в feature packages."
+derived_from:
+  - ../dna/governance.md
+  - ../dna/frontmatter.md
+  - feature-flow.md
+canonical_for:
+  - epic_directory_structure
+  - epic_document_boundaries
+  - epic_template_selection_rules
+  - epic_flow_stages
+  - epic_roadmap_rules
+  - epic_subissue_rules
+  - epic_quality_attributes
+  - epic_feature_handoff_rules
+status: active
+audience: humans_and_agents
+---
+
+# Epic Flow
+
+Epic - это управляемая инициатива крупнее одной delivery-feature. Он задаёт общий intent, границы, roadmap, решения, риски и subissue registry, но не подменяет feature package и не содержит code-level execution plan.
+
+FPF-основание:
+
+- **Bounded Contexts**: epic делит большую инициативу на смысловые контексты и delivery-slices, чтобы не смешивать бизнес, операции, финансы, UI/API и реализацию.
+- **Strict Distinction**: epic, feature, PRD, use case, ADR и implementation plan имеют разные owners и не должны подменять друг друга.
+- **Evidence Graph**: epic решения должны ссылаться на источники, stakeholder answers, specs, ADR или code facts.
+- **Q-Bundle**: качество epic нельзя свести к одному score; оно проверяется набором отдельных свойств ниже.
+
+## Package Rules
+
+1. Все документы одного epic живут в `memory-bank/epics/EP-XXX/`.
+2. `README.md` - routing layer и annotated index.
+3. `charter.md` - canonical owner intent: problem, outcome, scope/non-scope, stakeholder channels, source/evidence boundaries.
+4. `roadmap.md` - execution order owner: waves, gates, dependencies, stop rules and handoff protocol.
+5. `decision-log.md` - local decision ledger for decisions that affect the epic but do not require global ADR.
+6. `subissues.md` - registry of candidate and accepted delivery subissues, each mapped to roadmap waves and source `SLICE-*`/`UC-*`.
+7. `risks.md` - epic-level risk register for financial, operational, scope and delivery risks.
+8. `design.md`, `specs/**`, `diagrams/**`, `source-docs/**` are allowed when the epic needs normalized knowledge artifacts.
+9. `implementation-plan.md` не создаётся внутри epic. Code-level execution belongs to a separate `memory-bank/features/FT-<issue>/` package.
+10. Для canonical epic docs используй templates from `memory-bank/flows/templates/epic/`.
+
+## Layer Model
+
+| Layer | Primary docs | Owns | Must NOT define |
+| --- | --- | --- | --- |
+| Intent | `charter.md` | business/problem frame, scope, non-scope, source evidence, stakeholder channels | file paths, code steps, final implementation sequence |
+| Roadmap | `roadmap.md`, `subissues.md` | waves, dependencies, issue candidates, handoff gates | final code plan, exact migrations, test commands |
+| Governance | `decision-log.md`, `risks.md` | local decisions, risk controls, stop rules | global architecture policy unless promoted to ADR |
+| Knowledge | `design.md`, `specs/**`, `diagrams/**`, linked `UC-*` | bounded contexts, source-backed specs, contracts, scenario coverage | delivery issue ownership or code execution |
+| Execution | future `features/FT-<issue>/` | one approved delivery change with tests and rollout | reopening epic scope without updating epic owners |
+
+## Lifecycle
+
+```mermaid
+flowchart LR
+    DE["Draft Epic<br/>charter.md draft"] --> ER["Epic Ready<br/>charter.md active"]
+    ER --> RR["Roadmap Ready<br/>roadmap/subissues/risks active"]
+    RR --> EX["Execution<br/>delivery features created"]
+    EX --> DN["Done<br/>accepted subissues closed"]
+    ER --> CL["Cancelled"]
+    RR --> CL
+    EX --> CL
+```
+
+## Transition Gates
+
+### Bootstrap Epic
+
+- [ ] `README.md` создан
+- [ ] `charter.md` создан
+- [ ] `implementation-plan.md` отсутствует
+- [ ] если source docs уже известны, они отделены от derived specs
+
+### Draft -> Epic Ready
+
+- [ ] `charter.md` имеет `status: active`
+- [ ] scope/non-scope explicit
+- [ ] source/evidence boundaries explicit
+- [ ] stakeholder channels and decision process recorded
+- [ ] known out-of-scope topics recorded to prevent reopening
+
+### Epic Ready -> Roadmap Ready
+
+- [ ] `roadmap.md` active and names execution waves
+- [ ] `subissues.md` active and maps candidates to waves/slices
+- [ ] `risks.md` active and names controls/owners
+- [ ] `decision-log.md` active when non-trivial decisions exist
+- [ ] first delivery feature can be created without inventing epic-level facts
+
+### Roadmap Ready -> Execution
+
+- [ ] выбран один approved subissue or delivery slice
+- [ ] created/selected GitHub issue is linked to epic package
+- [ ] new `memory-bank/features/FT-<issue>/` package exists
+- [ ] new feature package imports only relevant epic refs, not the full epic scope
+- [ ] feature `feature.md`, and then `implementation-plan.md` follow `feature-flow.md`
+
+## Quality Bundle
+
+Epic quality is a Q-Bundle, not one scalar.
+
+| Quality | What must be visible | Review question |
+| --- | --- | --- |
+| Traceability | Source docs, decisions, requirements, UC and subissues linked by stable IDs | Can a reviewer trace each planned feature back to evidence? |
+| Decomposability | Bounded contexts and slices are separated | Can we create one delivery issue without dragging the whole epic? |
+| Roadmap clarity | Waves, dependencies, gates and stop rules are explicit | Does the team know what should happen first and why? |
+| Decision provenance | `decision-log.md` links facts, FPF reasoning and consequences | Is a decision backed by evidence rather than preference? |
+| Scope control | Non-scope and stop rules are explicit | Can we prevent accidental expansion during delivery? |
+| Risk governance | `risks.md` lists risks, controls and owners | Are high-impact financial/operator risks visible before code? |
+| Execution handoff | `subissues.md` and roadmap define feature-package inputs | Can a slice owner start without re-reading the whole epic? |
+| Evidence readiness | Open facts and confidence gaps are recorded | Do we know where facts are missing and who can close them? |
+| Change control | Epic changes update owner docs before downstream plans | Will scope/design drift be caught before implementation? |
+
+## Stable Identifiers
+
+| Prefix | Meaning | Owner |
+| --- | --- | --- |
+| `EP-SI-*` | Epic subissue candidate or accepted subissue | `subissues.md` |
+| `W*` | Roadmap wave | `roadmap.md` |
+| `HG-*` | Handoff gate before feature execution | `roadmap.md` |
+| `ERISK-*` | Epic-level risk | `risks.md` |
+| `DL-*` | Local decision log entry | `decision-log.md` |
+| `SLICE-*` | Candidate delivery slice | epic decomposition spec |
+
+## Boundary Rules
+
+1. Epic may define roadmap waves, but not file-level execution steps.
+2. Epic may define subissue candidates, but does not make them implementation-ready until a delivery issue and feature package exist.
+3. Epic may close local decisions with FPF and evidence. If a decision changes global project architecture, create ADR.
+4. Feature packages derived from an epic must link to relevant `EP-*` docs and preserve stable IDs instead of copying everything.
+5. If a feature discovers a new epic-level fact, update the epic owner document first, then update the feature.

--- a/memory-bank/flows/feature-flow.md
+++ b/memory-bank/flows/feature-flow.md
@@ -36,8 +36,9 @@ audience: humans_and_agents
 7. Смысл стабильных идентификаторов (`REQ-*`, `NS-*`, `CHK-*`, `STEP-*` и т.д.) задается в секции «Stable Identifiers» ниже.
 8. Acceptance scenarios (`SC-*`) покрывают vertical slice end-to-end: от входного события до наблюдаемого результата через все затронутые слои. Тестирование отдельного слоя в изоляции допустимо как implementation detail плана, но не заменяет end-to-end acceptance.
 9. **Связь с task tracker.** При создании feature package агент обязан добавить в исходную задачу или ticket ссылки на `feature.md` и, после появления, на `implementation-plan.md`. Это обеспечивает навигацию из task tracker к спецификации без ручного поиска по репозиторию.
-10. Если фича является частью более крупной инициативы, `feature.md` может зависеть от PRD из `memory-bank/prd/`, но PRD не заменяет сам feature package.
+10. Если фича является частью более крупной инициативы, `feature.md` может зависеть от PRD из `memory-bank/prd/` или epic из `memory-bank/epics/`, но upstream initiative document не заменяет сам feature package.
 11. Если фича создает новый устойчивый сценарий проекта или materially changes существующий, соответствующий `UC-*` в `memory-bank/use-cases/` должен быть создан или обновлен до closure.
+12. Если работа требует roadmap, risk register и нескольких delivery subissues, это не feature package. Создай или обнови `memory-bank/epics/EP-XXX/`, затем веди каждую approved delivery-единицу как отдельный `FT-<issue>/`.
 
 ## Выбор шаблона `feature.md`
 
@@ -125,6 +126,8 @@ flowchart LR
 7. Если численный target threshold относится только к одной delivery-единице, canonical owner — соответствующий `feature.md`. Поднимать такой KPI в project-level документ можно только после того, как он стал shared upstream fact для нескольких feature.
 8. Хороший `implementation-plan.md` начинается с discovery context: relevant paths, local reference patterns, unresolved questions, test surfaces и execution environment должны быть зафиксированы до sequencing изменений.
 9. Для рискованных, необратимых или внешне-эффективных действий `implementation-plan.md` должен явно описывать human approval gates и не скрывать их внутри prose шага.
+10. Если feature исполняет часть epic, `feature.md` должен ссылаться на relevant `EP-*` artifacts (`charter.md`, `roadmap.md`, `decision-log.md`, `subissues.md`, `risks.md`) и импортировать только нужные `SLICE-*`/`UC-*`, а не весь epic scope.
+11. Roadmap waves, cross-feature risks и subissue registry принадлежат `memory-bank/epics/EP-XXX/`, а не feature package.
 
 ## Test Ownership Summary
 

--- a/memory-bank/flows/templates/README.md
+++ b/memory-bank/flows/templates/README.md
@@ -2,11 +2,17 @@
 title: Templates Index
 doc_kind: governance
 doc_function: index
-purpose: Навигация по эталонным шаблонам документации проекта. Читать, чтобы завести PRD, use case, фичу, ADR, prompt или execution-документ без изобретения новой структуры.
+purpose: Навигация по эталонным шаблонам документации проекта. Читать, чтобы завести PRD, use case, epic, фичу, ADR, prompt или execution-документ без изобретения новой структуры.
 derived_from:
   - ../../dna/governance.md
   - prd/PRD-XXX.md
   - use-case/UC-XXX.md
+  - epic/README.md
+  - epic/charter.md
+  - epic/roadmap.md
+  - epic/decision-log.md
+  - epic/subissues.md
+  - epic/risks.md
   - feature/README.md
   - feature/implementation-plan.md
   - feature/short.md
@@ -14,6 +20,9 @@ derived_from:
   - adr/ADR-XXX.md
   - prompt/PROMPT-XXX.md
   - process/README.md
+  - process/process-card.md
+  - process/session-handoff.md
+  - process/lifecycle-protocol.md
 status: active
 audience: humans_and_agents
 ---
@@ -24,6 +33,12 @@ audience: humans_and_agents
 
 - [PRD-XXX: Product Initiative Name](prd/PRD-XXX.md) — компактный Product Requirements Document для инициативы, которая еще не разложена на один конкретный feature slice.
 - [UC-XXX: Use Case Name](use-case/UC-XXX.md) — канонический use case для устойчивого пользовательского или операционного сценария.
+- [Epic Templates](epic/README.md) — индекс шаблонов `EP-XXX` package.
+- [EP-XXX: Charter Template](epic/charter.md) — intent, scope, source/evidence and stakeholder channels.
+- [EP-XXX: Roadmap Template](epic/roadmap.md) — waves, dependencies, gates and stop rules.
+- [EP-XXX: Decision Log Template](epic/decision-log.md) — local epic decisions that do not require global ADR.
+- [EP-XXX: Subissues Template](epic/subissues.md) — candidate/accepted delivery subissue registry.
+- [EP-XXX: Risks Template](epic/risks.md) — epic-level risk register.
 - [FT-XXX Feature README Template](feature/README.md) — шаблон README для feature-каталога. Отвечает на вопрос: как оформить feature-level index.
 - [FT-XXX: Feature Template - Short](feature/short.md) — минимальный canonical feature для небольшой фичи. Отвечает на вопрос: как выглядит short feature-документ.
 - [FT-XXX: Feature Template - Large](feature/large.md) — canonical feature с assumptions, blockers, contracts, verify-слоем. Отвечает на вопрос: как выглядит large feature-документ.
@@ -31,3 +46,6 @@ audience: humans_and_agents
 - [ADR-XXX: Short Decision Name](adr/ADR-XXX.md) — шаблон ADR. Отвечает на вопрос: как зафиксировать архитектурное решение.
 - [PROMPT-XXX: Reusable Prompt Name](prompt/PROMPT-XXX.md) — шаблон reusable prompt-документа. Отвечает на вопрос: как сохранить исходную формулировку в frontmatter и улучшенный prompt в copyable body-блоке.
 - [PROC-XXX: Process Documentation Index](process/README.md) — шаблон индекса процесс-документов. Отвечает на вопрос: как собрать routing-layer для reusable process cards, session handoff и lifecycle protocol.
+- [PROC-XXX: Process Card](process/process-card.md) — компактный шаблон повторяемого процесса.
+- [PROC-XXX: Session Handoff](process/session-handoff.md) — шаблон передачи состояния между сессиями.
+- [PROC-XXX: Lifecycle Protocol](process/lifecycle-protocol.md) — шаблон длинного процесса с фазами, gates и verification.

--- a/memory-bank/flows/templates/epic/README.md
+++ b/memory-bank/flows/templates/epic/README.md
@@ -1,0 +1,20 @@
+---
+title: Epic Templates Index
+doc_kind: governance
+doc_function: template
+purpose: "Wrapper-шаблоны для `memory-bank/epics/EP-XXX/` packages: charter, roadmap, decision log, subissues and risks."
+derived_from:
+  - ../../epic-flow.md
+status: active
+audience: humans_and_agents
+---
+
+# Epic Templates Index
+
+Используй эти templates при создании нового `memory-bank/epics/EP-XXX/`.
+
+- [`charter.md`](charter.md) - intent, scope, source/evidence and stakeholder channels.
+- [`roadmap.md`](roadmap.md) - waves, dependencies, gates and stop rules.
+- [`decision-log.md`](decision-log.md) - local epic decisions that do not require global ADR.
+- [`subissues.md`](subissues.md) - candidate/accepted delivery subissue registry.
+- [`risks.md`](risks.md) - epic-level risk register.

--- a/memory-bank/flows/templates/epic/charter.md
+++ b/memory-bank/flows/templates/epic/charter.md
@@ -1,0 +1,62 @@
+---
+title: "EP-XXX: Charter Template"
+doc_kind: governance
+doc_function: template
+purpose: "Шаблон epic charter: canonical intent, scope/non-scope, evidence and acceptance boundaries for a multi-feature initiative."
+derived_from:
+  - ../../epic-flow.md
+status: active
+audience: humans_and_agents
+template_target_path: ../../../epics/EP-XXX/charter.md
+---
+
+# EP-XXX: Charter Template
+
+```markdown
+---
+title: "EP-XXX: <Epic Name>"
+doc_kind: epic
+doc_function: canonical
+purpose: "<What this epic governs and why it is larger than one feature>"
+derived_from:
+  - ../../flows/epic-flow.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - feature_issue_ids_not_approved
+---
+
+# EP-XXX: <Epic Name>
+
+## Problem
+
+## Outcome
+
+## Stakeholder Channels
+
+| Channel | ID / URL | Purpose |
+| --- | --- | --- |
+
+## Scope
+
+- `REQ-01`
+
+## Non-Scope
+
+- `NS-01`
+
+## Source / Evidence Boundaries
+
+| Source | Authority | Refresh rule |
+| --- | --- | --- |
+
+## Acceptance
+
+| Criterion | Check |
+| --- | --- |
+
+## Handoff
+
+Delivery work must be created as separate `memory-bank/features/FT-<issue>/` packages.
+```

--- a/memory-bank/flows/templates/epic/decision-log.md
+++ b/memory-bank/flows/templates/epic/decision-log.md
@@ -1,0 +1,51 @@
+---
+title: "EP-XXX: Decision Log Template"
+doc_kind: governance
+doc_function: template
+purpose: "Шаблон epic-local decision log for decisions backed by evidence/FPF that do not require global ADR."
+derived_from:
+  - ../../epic-flow.md
+status: active
+audience: humans_and_agents
+template_target_path: ../../../epics/EP-XXX/decision-log.md
+---
+
+# EP-XXX: Decision Log Template
+
+```markdown
+---
+title: "EP-XXX: Decision Log"
+doc_kind: epic
+doc_function: decision_log
+purpose: "<Local decisions for this epic>"
+derived_from:
+  - charter.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - global_architecture_policy_without_adr
+---
+
+# EP-XXX: Decision Log
+
+## FPF Reading Rule
+
+Record facts, assumptions, reasoning and consequences separately.
+
+## DL-01: <Decision Name>
+
+**Date:** YYYY-MM-DD
+
+**Question:**
+
+**Status:** Proposed / Resolved / Superseded.
+
+**Facts:**
+
+**Reasoning:**
+
+**Decision:**
+
+**Consequences:**
+```

--- a/memory-bank/flows/templates/epic/risks.md
+++ b/memory-bank/flows/templates/epic/risks.md
@@ -1,0 +1,33 @@
+---
+title: "EP-XXX: Risks Template"
+doc_kind: governance
+doc_function: template
+purpose: "Шаблон epic-level risk register for financial, operational, scope and delivery risks."
+derived_from:
+  - ../../epic-flow.md
+status: active
+audience: humans_and_agents
+template_target_path: ../../../epics/EP-XXX/risks.md
+---
+
+# EP-XXX: Risks Template
+
+```markdown
+---
+title: "EP-XXX: Risks"
+doc_kind: epic
+doc_function: risk_register
+purpose: "<Risk register for this epic>"
+derived_from:
+  - charter.md
+  - roadmap.md
+status: draft
+audience: humans_and_agents
+---
+
+# EP-XXX: Risks
+
+| Risk ID | Risk | Impact | Control | Owner | Status |
+| --- | --- | --- | --- | --- | --- |
+| `ERISK-01` |  |  |  |  | open |
+```

--- a/memory-bank/flows/templates/epic/roadmap.md
+++ b/memory-bank/flows/templates/epic/roadmap.md
@@ -1,0 +1,50 @@
+---
+title: "EP-XXX: Roadmap Template"
+doc_kind: governance
+doc_function: template
+purpose: "Шаблон epic roadmap: execution waves, dependencies, gates and stop rules before creating delivery feature packages."
+derived_from:
+  - ../../epic-flow.md
+status: active
+audience: humans_and_agents
+template_target_path: ../../../epics/EP-XXX/roadmap.md
+---
+
+# EP-XXX: Roadmap Template
+
+```markdown
+---
+title: "EP-XXX: Roadmap"
+doc_kind: epic
+doc_function: roadmap
+purpose: "<How the epic should be executed through delivery waves>"
+derived_from:
+  - charter.md
+  - subissues.md
+  - risks.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - code_steps
+  - final_database_schema
+  - production_rollout_dates
+---
+
+# EP-XXX: Roadmap
+
+## Waves
+
+| Wave | Target | Depends on | Exit gate |
+| --- | --- | --- | --- |
+
+## First Slice Recommendation
+
+## Handoff Gates
+
+| Gate | Required evidence |
+| --- | --- |
+
+## Stop Rules
+
+- Stop if a feature needs an epic-level decision that is not recorded.
+```

--- a/memory-bank/flows/templates/epic/subissues.md
+++ b/memory-bank/flows/templates/epic/subissues.md
@@ -1,0 +1,43 @@
+---
+title: "EP-XXX: Subissues Template"
+doc_kind: governance
+doc_function: template
+purpose: "Шаблон registry for candidate and accepted delivery subissues under an epic."
+derived_from:
+  - ../../epic-flow.md
+status: active
+audience: humans_and_agents
+template_target_path: ../../../epics/EP-XXX/subissues.md
+---
+
+# EP-XXX: Subissues Template
+
+```markdown
+---
+title: "EP-XXX: Subissues"
+doc_kind: epic
+doc_function: subissue_registry
+purpose: "<Delivery subissue registry for this epic>"
+derived_from:
+  - charter.md
+  - roadmap.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - code_steps
+---
+
+# EP-XXX: Subissues
+
+## Registry
+
+| ID | Candidate issue title | Roadmap wave | Source slices / UC | Status | Feature package |
+| --- | --- | --- | --- | --- | --- |
+| `EP-SI-01` |  |  |  | candidate | TBD |
+
+## Creation Rules
+
+- Create GitHub subissue only after scope is approved.
+- Create `memory-bank/features/FT-<issue>/` after the issue exists.
+- Link the feature package back to this epic and relevant source docs.
+```


### PR DESCRIPTION
## What

Adds a generic epic documentation layer to the memory-bank template:

- introduces `memory-bank/epics/` as the destination for multi-feature initiatives
- adds `memory-bank/flows/epic-flow.md` with lifecycle, gates, boundaries, identifiers, and feature handoff rules
- adds epic templates for charter, roadmap, decision log, subissues, and risks
- updates root, flows, templates, features, and feature-flow indexes to route epic work consistently

## Why

`feature-flow.md` now needs a governed destination for work that is larger than one delivery feature. The new epic layer keeps roadmap, cross-feature risks, and subissue registries out of feature packages while preserving handoff into `FT-<issue>/` packages.

## Validation

- `python3 scripts/check_memory_bank_index.py`
- `git diff --check`
- `rg -n "EP-2870|PR-008|Slots|слот|Mercury|Merchantly|CloudPayments|kiiiosk|Bugsnag|alfagen|mercury|#2870" memory-bank`