### PR TITLE
docs: add epic intake brief template

### DIFF
--- a/memory-bank/features/FT-014/README.md
+++ b/memory-bank/features/FT-014/README.md
@@ -1,0 +1,37 @@
+---
+title: "FT-014: Epic Intake Brief Template"
+doc_kind: feature
+doc_function: index
+purpose: "Навигация по feature package для issue 14: добавить lightweight epic intake brief template и связанные governance updates."
+derived_from:
+  - ../../dna/governance.md
+  - brief.md
+  - design.md
+  - implementation-plan.md
+  - decision-log.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-014: Epic Intake Brief Template
+
+## О разделе
+
+Этот package ведет delivery-единицу из GitHub issue 14: добавить легкий epic intake brief template без переноса downstream-specific content.
+
+## Аннотированный индекс
+
+- [`brief.md`](brief.md)
+  Читать, когда нужно: проверить problem space, scope/non-scope, constraints и canonical verify contract для этой delivery-единицы.
+
+- [`design.md`](design.md)
+  Читать, когда нужно: проверить выбранный solution подход, C4 applicability, локальные решения и границы template/governance changes.
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Читать, когда нужно: выполнить изменение по шагам, сверить affected paths, checks и evidence expectations.
+
+- [`decision-log.md`](decision-log.md)
+  Читать, когда нужно: увидеть feature-local решения, закрытые через FPF reasoning и привязанные к фактам из issue/docs.
+
+- [`feature-review-report.md`](feature-review-report.md)
+  Читать, когда нужно: проверить итоги bounded review-improve циклов по комплекту feature-документов.

--- a/memory-bank/features/FT-014/brief.md
+++ b/memory-bank/features/FT-014/brief.md
@@ -1,0 +1,125 @@
+---
+title: "FT-014: Epic Intake Brief Template"
+doc_kind: feature
+doc_function: canonical
+purpose: "Canonical brief для добавления lightweight epic intake brief template. Фиксирует problem space, scope и verify без смешения с solution design или execution plan."
+derived_from:
+  - ../../flows/feature-flow.md
+  - ../../flows/epic-flow.md
+status: active
+delivery_status: in_progress
+audience: humans_and_agents
+source_issue: "https://github.com/dapi/memory-bank/issues/14"
+must_not_define:
+  - implementation_sequence
+  - solution_space
+---
+
+# FT-014: Epic Intake Brief Template
+
+## What
+
+### Problem
+
+GitHub issue 14 фиксирует gap в epic lifecycle: текущий epic package начинается с полного setup через `charter.md`, `roadmap.md`, `risks.md` и `subissues.md`, но до полного epic setup иногда нужен более легкий intake-документ. В качестве source указан `dapi/zelma: memory-bank/flows/templates/epic/brief.md`, при этом issue явно запрещает переносить `zelma`-specific content.
+
+### Outcome
+
+| Metric ID | Metric | Baseline | Target | Measurement method |
+| --- | --- | --- | --- | --- |
+| `MET-01` | Epic intake template discoverability | `memory-bank/flows/templates/epic/brief.md` отсутствует | Новый template доступен из epic template indexes | `CHK-01`, `CHK-02` |
+| `MET-02` | Boundary clarity | `epic-flow.md` не описывает lightweight intake brief | `epic-flow.md` явно говорит, что brief не заменяет charter/roadmap/subissues/risks и не владеет implementation sequence | `CHK-02` |
+
+### Scope
+
+- `REQ-01` Добавить `memory-bank/flows/templates/epic/brief.md` как generic lightweight intake layer для epic proposal.
+- `REQ-02` Обновить `memory-bank/flows/templates/epic/README.md`, чтобы новый epic brief template был discoverable.
+- `REQ-03` Обновить `memory-bank/flows/templates/README.md`, если это нужно для reachability и template index consistency.
+- `REQ-04` Уточнить `memory-bank/flows/epic-flow.md`, что intake `brief.md` не заменяет canonical full epic package owners и не владеет implementation sequence.
+- `REQ-05` Не переносить `zelma`-specific content в governed template/governance docs.
+- `REQ-06` Сохранить green index audit для `memory-bank/`.
+
+### Non-Scope
+
+- `NS-01` Не создавать instantiated epic package в `memory-bank/epics/`.
+- `NS-02` Не менять feature-flow semantics за пределами документов, необходимых для ведения этой feature.
+- `NS-03` Не добавлять roadmap/subissue/risk behavior в epic brief template.
+- `NS-04` Не переносить product/domain/project-specific content из downstream repositories.
+
+### Constraints / Assumptions
+
+- `ASM-01` Source template from `dapi/zelma` is used only as evidence for shape and intent, not as authoritative downstream content.
+- `ASM-02` Current repository has no runtime application; delivery is Markdown/governance update plus link audit.
+- `CON-01` Full epic package remains authoritative for roadmap, subissues, risks and local epic decisions per `memory-bank/flows/epic-flow.md`.
+- `CON-02` Governed docs in `memory-bank/` must keep YAML frontmatter with required `status` and valid relative links.
+- `CON-03` Target template/governance docs must remain generic and not mention `zelma`-specific terms.
+
+## Design Requirement Decision
+
+| Decision | Reason | Downstream owner |
+| --- | --- | --- |
+| `Design required: yes` | The change updates governed templates and `epic-flow.md` boundary semantics; selected boundaries and local decisions must not be hidden in `brief.md` or execution plan. | `design.md` |
+
+## Verify
+
+### Exit Criteria
+
+- `EC-01` Epic brief template exists and includes problem, outcome, rough scope, non-scope and readiness notes.
+- `EC-02` Epic template indexes route to the new brief template.
+- `EC-03` `epic-flow.md` preserves full package authority for charter/roadmap/subissues/risks and excludes implementation sequencing from intake brief.
+- `EC-04` Target template/governance docs contain no source-project-specific `zelma` content.
+- `EC-05` `python3 scripts/check_memory_bank_index.py` passes.
+
+### Traceability matrix
+
+| Requirement ID | Problem refs | Acceptance refs | Checks | Evidence IDs |
+| --- | --- | --- | --- | --- |
+| `REQ-01` | `ASM-01`, `CON-03` | `EC-01`, `SC-01`, `NEG-01` | `CHK-01`, `CHK-02`, `CHK-03` | `EVID-01`, `EVID-02`, `EVID-03` |
+| `REQ-02` | `CON-02` | `EC-02`, `SC-01` | `CHK-01`, `CHK-02` | `EVID-01`, `EVID-02` |
+| `REQ-03` | `CON-02` | `EC-02` | `CHK-01`, `CHK-02` | `EVID-01`, `EVID-02` |
+| `REQ-04` | `CON-01` | `EC-03`, `SC-02` | `CHK-02` | `EVID-02` |
+| `REQ-05` | `ASM-01`, `CON-03` | `EC-04`, `NEG-01` | `CHK-03` | `EVID-03` |
+| `REQ-06` | `ASM-02`, `CON-02` | `EC-05` | `CHK-01`, `CHK-04` | `EVID-01`, `EVID-04` |
+
+### Acceptance Scenarios
+
+- `SC-01` A reader creating an early epic proposal can find `memory-bank/flows/templates/epic/brief.md` and instantiate a lightweight document with problem, outcome, rough scope, non-scope and readiness notes before full epic setup.
+- `SC-02` A reader of `epic-flow.md` can tell that full epic package owners remain authoritative for roadmap, accepted subissues, risks and decisions, while feature execution still belongs to `memory-bank/features/FT-<issue>/`.
+
+### Negative / Edge Coverage
+
+- `NEG-01` If source-project terms or implementation sequence appear in target epic brief template/governance docs, the change is rejected until those terms are removed or moved to the correct owner.
+
+### Checks
+
+| Check ID | Covers | How to check | Expected result | Evidence path |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `EC-01`, `EC-02`, `EC-05` | `python3 scripts/check_memory_bank_index.py` | Audit reports `Result: OK` | `artifacts/ft-014/verify/chk-01/` |
+| `CHK-02` | `EC-01`, `EC-02`, `EC-03` | Review changed docs: `memory-bank/flows/templates/epic/brief.md`, `memory-bank/flows/templates/epic/README.md`, `memory-bank/flows/templates/README.md`, `memory-bank/flows/epic-flow.md` | Required sections and boundary wording are present and not contradictory | `artifacts/ft-014/verify/chk-02/` |
+| `CHK-03` | `EC-04`, `NEG-01` | `rg -n "zelma|Zelma|dapi/zelma" memory-bank/flows/templates/epic/brief.md memory-bank/flows/templates/epic/README.md memory-bank/flows/templates/README.md memory-bank/flows/epic-flow.md` | No matches | `artifacts/ft-014/verify/chk-03/` |
+| `CHK-04` | `EC-05` | `git diff --check` | No whitespace errors or conflict markers | `artifacts/ft-014/verify/chk-04/` |
+
+### Test matrix
+
+| Check ID | Evidence IDs | Evidence path |
+| --- | --- | --- |
+| `CHK-01` | `EVID-01` | `artifacts/ft-014/verify/chk-01/` |
+| `CHK-02` | `EVID-02` | `artifacts/ft-014/verify/chk-02/` |
+| `CHK-03` | `EVID-03` | `artifacts/ft-014/verify/chk-03/` |
+| `CHK-04` | `EVID-04` | `artifacts/ft-014/verify/chk-04/` |
+
+### Evidence
+
+- `EVID-01` Output of `python3 scripts/check_memory_bank_index.py`.
+- `EVID-02` Review note or diff evidence showing required template/index/flow wording.
+- `EVID-03` Output proving no source-project terms in target template/governance docs.
+- `EVID-04` Output of `git diff --check`.
+
+### Evidence contract
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checks |
+| --- | --- | --- | --- | --- |
+| `EVID-01` | Link audit output | implementer | `artifacts/ft-014/verify/chk-01/` | `CHK-01` |
+| `EVID-02` | Review note or relevant diff excerpt | implementer / reviewer | `artifacts/ft-014/verify/chk-02/` | `CHK-02` |
+| `EVID-03` | `rg` output | implementer | `artifacts/ft-014/verify/chk-03/` | `CHK-03` |
+| `EVID-04` | `git diff --check` output | implementer | `artifacts/ft-014/verify/chk-04/` | `CHK-04` |

--- a/memory-bank/features/FT-014/decision-log.md
+++ b/memory-bank/features/FT-014/decision-log.md
@@ -1,0 +1,34 @@
+---
+title: "FT-014: Decision Log"
+doc_kind: feature-support
+doc_function: reference
+purpose: "Feature-local ledger for FPF-backed decisions made while adding lightweight epic intake brief template."
+derived_from:
+  - brief.md
+  - design.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_014_scope
+  - ft_014_acceptance_criteria
+  - ft_014_execution_sequence
+---
+
+# FT-014: Decision Log
+
+## Decision Method
+
+Decisions use FPF in plain language:
+
+- Bounded Contexts: keep intake, full epic governance and feature execution as separate semantic frames.
+- Strict Distinction: do not let a proposal document become a roadmap, accepted subissue registry, risk register or execution plan.
+- Evidence Graph: tie decisions to issue 14, the source template and current repository governance docs.
+- Canonical Reasoning Cycle: propose a local hypothesis, derive consequences, then verify against repository checks and document review.
+
+## Decisions
+
+| Decision ID | Question Closed | Available facts | FPF reasoning | Decision | Consequences |
+| --- | --- | --- | --- | --- | --- |
+| `DL-01` | Does the new epic `brief.md` replace full epic owners? | Issue 14 says the current epic package has `charter/roadmap/risks/subissues`; acceptance says full epic package remains authoritative for roadmap/subissues/risks; `epic-flow.md` already gives separate owners for these docs. | Bounded Contexts separates early intake from full epic governance; Strict Distinction prevents one document from owning roadmap, risk and execution semantics. | The brief is optional intake only and does not replace `charter.md`, `roadmap.md`, `subissues.md`, `risks.md` or `decision-log.md`. | Reflected as `SD-01`; update `epic-flow.md` package rules, layer model and boundary rules. |
+| `DL-02` | How much of the downstream source template may be reused? | Issue 14 names `dapi/zelma: memory-bank/flows/templates/epic/brief.md` as source and says not to transfer `zelma`-specific content; current repo uses governed wrapper templates with frontmatter and embedded instantiated contract. | Evidence Graph requires claims to stay anchored to source carriers; Strict Distinction separates generic template semantics from downstream project content. | Reuse only generic shape: problem, outcome, rough scope, non-scope, candidate feature brief links and readiness notes; normalize wording/frontmatter to this repository's template style. | Reflected as `SOL-01`, `SOL-04`, `INV-01`; verify with targeted source-leakage grep. |
+| `DL-03` | Does this docs-only change need C4 artifact or ADR? | `feature-flow.md` requires design when governance/template contracts need explicit reasoning; C4 is unnecessary when no runtime/API/storage/integration/security boundary changes; issue scope is Markdown governance/template docs. | Strict Distinction separates solution reasoning from architecture model; Evidence Graph says C4/ADR must be evidence-backed, not ceremonial. | Create `design.md` for local solution decisions, set `C4-00: not required`, and do not create ADR. | Reflected as `C4-00`, `SD-03`; implementation plan can proceed after active `design.md`. |

--- a/memory-bank/features/FT-014/design.md
+++ b/memory-bank/features/FT-014/design.md
@@ -1,0 +1,106 @@
+---
+title: "FT-014: Design"
+doc_kind: feature
+doc_function: canonical
+purpose: "Solution-space документ для FT-014. Фиксирует выбранный подход к lightweight epic intake template, boundary updates и локальные решения без переопределения problem space или execution contract."
+derived_from:
+  - brief.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_014_scope
+  - ft_014_acceptance_criteria
+  - ft_014_evidence_contract
+  - implementation_sequence
+---
+
+# FT-014: Design
+
+## Design Pack
+
+| Artifact | Role | Owns |
+| --- | --- | --- |
+| `design.md` | Feature-local solution owner | `SOL-*`, `ALT-*`, `TRD-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` |
+| `decision-log.md` | Feature-local FPF decision ledger | `DL-*` reasoning records for decisions that do not require ADR |
+
+## Context
+
+Issue 14 asks for a generic lightweight epic intake brief template based on a downstream source template, plus updates to epic template README and `epic-flow.md`. The design problem is boundary control: the new brief must be useful before full epic setup without becoming a second owner for charter, roadmap, risks, subissues or feature execution.
+
+## C4 Applicability
+
+| C4 ID | Decision | Trigger / reason | Artifact |
+| --- | --- | --- | --- |
+| `C4-00` | `not required` | The change is documentation/template governance only; it does not change runtime, deployable, API, storage, integration, security or component boundaries. | `none` |
+
+## Selected Solution
+
+- `SOL-01` Add `memory-bank/flows/templates/epic/brief.md` as a governed wrapper-template with instantiated frontmatter/body for a lightweight epic intake brief.
+- `SOL-02` Register the new template in `memory-bank/flows/templates/epic/README.md` and `memory-bank/flows/templates/README.md` so navigation and index audit remain coherent.
+- `SOL-03` Update `memory-bank/flows/epic-flow.md` with an intake layer, optional-intake gate and boundary rules that keep full epic package owners authoritative.
+- `SOL-04` Keep source adaptation minimal: reuse only generic structure from the downstream source and avoid source-project-specific content in target template/governance docs.
+
+## Alternatives Considered
+
+| Alternative ID | Option | Why not selected |
+| --- | --- | --- |
+| `ALT-01` | Copy the source template verbatim | Rejected because issue 14 explicitly forbids moving downstream-specific content; the target repo also has its own wrapper/template style. |
+| `ALT-02` | Add only the template file and skip `epic-flow.md` | Rejected because issue 14 explicitly asks to clarify that brief does not replace charter/roadmap and does not own implementation sequence. |
+| `ALT-03` | Fold intake fields into `charter.md` only | Rejected because the issue asks for a lighter document before full epic setup, not a heavier charter template. |
+
+## Trade-offs
+
+| Trade-off ID | Decision | Benefit | Cost / Risk |
+| --- | --- | --- | --- |
+| `TRD-01` | Keep intake brief optional and draft-oriented | Allows early proposal capture without requiring full epic package upfront | Requires explicit boundary wording to prevent duplicate ownership |
+| `TRD-02` | Update both local and global template indexes | Keeps audit reachability and discoverability strong | Slightly expands change surface beyond the issue's explicit epic README line, but only for index consistency |
+
+## Accepted Local Decisions
+
+- `SD-01` The epic intake `brief.md` is an optional early layer and not a canonical replacement for `charter.md`, `roadmap.md`, `subissues.md`, `risks.md` or `decision-log.md`.
+- `SD-02` The intake template may include candidate feature brief links as readiness context, but accepted delivery subissues remain owned by `subissues.md`.
+- `SD-03` No ADR is required because the decision is feature-local template governance and does not define reusable architecture or runtime boundaries.
+
+## Contracts
+
+| Contract ID | Input / Output | Producer / Consumer | Semantics / Constraints |
+| --- | --- | --- | --- |
+| `CTR-01` | `memory-bank/flows/templates/epic/brief.md` | Template maintainer / epic author | Must include problem, outcome, rough scope, non-scope and readiness notes; must not define implementation sequence, feature acceptance contracts or selected solution. |
+| `CTR-02` | `memory-bank/flows/epic-flow.md` | Governance maintainer / epic and feature authors | Must state that full epic package owners remain authoritative for roadmap, accepted subissues, risks and decisions. |
+| `CTR-03` | Template indexes | Template maintainer / index audit | Must link the new template from local epic template index and global templates index. |
+
+## Invariants
+
+- `INV-01` Intake brief content must remain generic and source-backed; no source-project-specific terms may appear in target template/governance docs.
+- `INV-02` The new brief must not create an `implementation-plan.md` path inside epic packages.
+- `INV-03` If intake facts mature into authoritative epic scope or roadmap, the owner becomes the full epic package document, not the intake brief.
+
+## Failure Modes
+
+- `FM-01` Duplicate ownership: authors treat intake brief as authoritative after full epic setup. Mitigation: add layer and boundary rules in `epic-flow.md`.
+- `FM-02` Source leakage: downstream project terms appear in generic template docs. Mitigation: explicit `CHK-03` grep and review.
+- `FM-03` Broken reachability: new template or feature docs are orphaned. Mitigation: update indexes and run `CHK-01`.
+
+## Rollout / Backout
+
+| Stage ID | Stage | Entry condition | Backout |
+| --- | --- | --- | --- |
+| `RB-01` | Add docs and indexes in current branch | `brief.md` and `design.md` active for FT-014 | Revert only FT-014 and issue-scope docs in this branch before merge |
+| `RB-02` | Verify locally | Changes are present | If audit fails, update owner/index docs before continuing |
+
+## ADR / External Design Dependencies
+
+| Artifact | Current status | Used for | Rule |
+| --- | --- | --- | --- |
+| `none` | `n/a` | No reusable architecture decision is required | Do not create ADR for feature-local template governance |
+
+## Traceability
+
+| Requirement ID | Solution refs | Contracts / invariants | Failure / rollout refs |
+| --- | --- | --- | --- |
+| `REQ-01` | `SOL-01`, `TRD-01`, `SD-01` | `CTR-01`, `INV-01`, `INV-02` | `FM-01`, `FM-02`, `RB-01` |
+| `REQ-02` | `SOL-02`, `TRD-02` | `CTR-03` | `FM-03`, `RB-02` |
+| `REQ-03` | `SOL-02`, `TRD-02` | `CTR-03` | `FM-03`, `RB-02` |
+| `REQ-04` | `SOL-03`, `SD-01`, `SD-02` | `CTR-02`, `INV-02`, `INV-03` | `FM-01`, `RB-01` |
+| `REQ-05` | `SOL-04` | `INV-01` | `FM-02`, `RB-02` |
+| `REQ-06` | `SOL-02`, `SOL-03` | `CTR-03` | `FM-03`, `RB-02` |

--- a/memory-bank/features/FT-014/feature-review-report.md
+++ b/memory-bank/features/FT-014/feature-review-report.md
@@ -1,0 +1,201 @@
+---
+title: "FT-014: Feature Review Report"
+doc_kind: feature-support
+doc_function: reference
+purpose: "Bounded review-improve report for FT-014 feature documents and explicitly scoped linked artifacts."
+derived_from:
+  - brief.md
+  - design.md
+  - implementation-plan.md
+  - decision-log.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_014_scope
+  - ft_014_selected_design
+  - ft_014_acceptance_criteria
+  - ft_014_execution_sequence
+---
+
+# FT-014: Feature Review Report
+
+## Scope
+
+Reviewed package:
+
+- `memory-bank/features/FT-014/README.md`
+- `memory-bank/features/FT-014/brief.md`
+- `memory-bank/features/FT-014/design.md`
+- `memory-bank/features/FT-014/implementation-plan.md`
+- `memory-bank/features/FT-014/decision-log.md`
+
+Explicitly scoped linked artifacts:
+
+- `memory-bank/flows/templates/epic/brief.md`
+- `memory-bank/flows/templates/epic/README.md`
+- `memory-bank/flows/templates/README.md`
+- `memory-bank/flows/epic-flow.md`
+- `memory-bank/features/README.md`
+
+## Cycle 1
+
+### Review Summary
+
+Initial feature package and linked artifacts were created from issue 14, current `feature-flow.md`, current `epic-flow.md`, existing epic templates and the downstream source template. The package had coherent scope, design and execution ownership, but one linked artifact was missing.
+
+### Critical Findings
+
+| ID | Finding | Evidence | Correction |
+| --- | --- | --- | --- |
+| `C1-CRIT-01` | `FT-014/README.md` linked to `feature-review-report.md`, but the report file did not exist. This broke `REQ-06` / `EC-05`. | `python3 scripts/check_memory_bank_index.py` reported broken link `memory-bank/features/FT-014/README.md -> memory-bank/features/FT-014/feature-review-report.md`. | Create `memory-bank/features/FT-014/feature-review-report.md` and keep it linked from `README.md`. |
+
+### Important Findings
+
+None.
+
+### FPF-Closed Questions
+
+None. The finding was a missing carrier/link artifact, not a blocking product or design ambiguity.
+
+### Changes Made
+
+- Created `feature-review-report.md` as the missing linked artifact.
+
+### Human Gate
+
+No.
+
+## Cycle 2
+
+### Review Summary
+
+Repeated review after creating the report artifact. Link audit, diff hygiene and source-leakage checks passed. The feature docs were internally coherent on scope/design/plan traceability, but lifecycle/process state still lagged behind the actual work state.
+
+### Critical Findings
+
+None.
+
+### Important Findings
+
+| ID | Finding | Evidence | Correction |
+| --- | --- | --- | --- |
+| `C2-IMP-01` | `brief.md` had `delivery_status: planned` even though target docs were already edited and `implementation-plan.md` was active. | `feature-flow.md` says transition to execution uses `brief.md -> delivery_status: in_progress`; FT-014 target changes already exist in the branch. | Set `delivery_status: in_progress` in `brief.md`. |
+| `C2-IMP-02` | Source GitHub issue did not yet have a feature package reference. | `feature-flow.md` Package Rule 12 requires adding a link/reference to the source task when creating the feature package. | Add a comment to issue 14 with the repo-relative feature package path. |
+
+### FPF-Closed Questions
+
+None. These were lifecycle/process corrections, not ambiguous product or solution decisions.
+
+### Changes Made
+
+- Updated `brief.md` to `delivery_status: in_progress`.
+- Added source issue reference to issue 14: https://github.com/dapi/memory-bank/issues/14#issuecomment-4915979557.
+
+### Human Gate
+
+No.
+
+## Cycle 3
+
+### Review Summary
+
+Link audit, diff hygiene, source-leakage check and source issue reference were valid. Cross-document review found one lifecycle consistency issue inside `epic-flow.md`: the new optional intake gate existed in prose/gates but not in the lifecycle diagram.
+
+### Critical Findings
+
+None.
+
+### Important Findings
+
+| ID | Finding | Evidence | Correction |
+| --- | --- | --- | --- |
+| `C3-IMP-01` | `epic-flow.md` described optional intake brief in package rules and transition gates, but the lifecycle diagram still started at draft charter. | `epic-flow.md` had `### Optional Intake Brief`, while the Mermaid lifecycle began with `DE["Draft Epic<br/>charter.md draft"]`. | Add an optional intake node leading into draft epic in the lifecycle diagram. |
+
+### FPF-Closed Questions
+
+None. The correction aligns an existing accepted local decision (`SD-01`) across two sections of the same owner document.
+
+### Changes Made
+
+- Updated `memory-bank/flows/epic-flow.md` lifecycle diagram to include `Optional Intake<br/>brief.md draft`.
+
+### Human Gate
+
+No.
+
+## Cycle 4
+
+### Review Summary
+
+Checks stayed green, but the report itself was not audit-friendly: cycle sections were ordered as Cycle 1, Cycle 3, Cycle 2.
+
+### Critical Findings
+
+None.
+
+### Important Findings
+
+| ID | Finding | Evidence | Correction |
+| --- | --- | --- | --- |
+| `C4-IMP-01` | Review report cycle sections were out of chronological order. | `feature-review-report.md` showed `## Cycle 3` before `## Cycle 2`. | Reorder sections to Cycle 1, Cycle 2, Cycle 3, then record Cycle 4. |
+
+### FPF-Closed Questions
+
+None. This was report structure cleanup, not a blocking decision.
+
+### Changes Made
+
+- Reordered Cycle 2 and Cycle 3 sections.
+- Added Cycle 4 record.
+
+### Human Gate
+
+No.
+
+## Cycle 5
+
+### Review Summary
+
+Final allowed cycle. Link audit passed, diff hygiene passed, targeted source-leakage check returned no matches, and report sections are ordered chronologically. No critical or important findings remain.
+
+### Critical Findings
+
+None.
+
+### Important Findings
+
+None.
+
+### FPF-Closed Questions
+
+None. No blocking open questions remained.
+
+### Changes Made
+
+None.
+
+### Human Gate
+
+No.
+
+## Final Summary
+
+| Field | Value |
+| --- | --- |
+| Status | `done` |
+| Cycles executed | `5` |
+| Human gate | `no` |
+| Decision log | `memory-bank/features/FT-014/decision-log.md` |
+| Source issue reference | https://github.com/dapi/memory-bank/issues/14#issuecomment-4915979557 |
+
+Closed critical / important findings:
+
+- `C1-CRIT-01` Created missing `feature-review-report.md` linked from `FT-014/README.md`.
+- `C2-IMP-01` Updated feature lifecycle from `planned` to `in_progress`.
+- `C2-IMP-02` Added feature package reference to GitHub issue 14.
+- `C3-IMP-01` Added optional intake node to `epic-flow.md` lifecycle diagram.
+- `C4-IMP-01` Reordered review report cycles chronologically.
+
+Remaining critical / important findings:
+
+- None.

--- a/memory-bank/features/FT-014/implementation-plan.md
+++ b/memory-bank/features/FT-014/implementation-plan.md
@@ -1,0 +1,137 @@
+---
+title: "FT-014: Implementation Plan"
+doc_kind: feature
+doc_function: derived
+purpose: "Execution-план реализации FT-014. Фиксирует discovery context, шаги, риски и test strategy без переопределения canonical problem или solution facts."
+derived_from:
+  - brief.md
+  - design.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_014_scope
+  - ft_014_selected_design
+  - ft_014_acceptance_criteria
+  - ft_014_blocker_state
+---
+
+# FT-014: Implementation Plan
+
+## Цель текущего плана
+
+Реализовать issue 14 как documentation/template delivery: добавить lightweight epic intake brief template, обновить связанные indexes and `epic-flow.md`, затем подтвердить acceptance через link audit, whitespace check и targeted source-leakage check.
+
+## Grounding / Support References
+
+| Document | Role in this plan | Facts reused | Conflict action |
+| --- | --- | --- | --- |
+| `brief.md` | canonical problem / verify owner | `REQ-*`, `SC-*`, `NEG-*`, `CHK-*`, `EVID-*` | Update `brief.md` first |
+| `design.md` | conditional solution owner | `SOL-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` | Update `design.md` first |
+| `decision-log.md` | feature-local FPF reasoning ledger | `DL-*` decisions and rationale | Update `decision-log.md` when closing blocking questions |
+
+## Current State / Reference Points
+
+| Path / module | Current role | Why relevant | Reuse / mirror |
+| --- | --- | --- | --- |
+| `memory-bank/flows/templates/epic/README.md` | Current epic template index | Must route to new `brief.md` template | Keep annotated bullet style |
+| `memory-bank/flows/templates/README.md` | Global templates index | Must keep all templates reachable | Add derived_from and bullet for epic brief |
+| `memory-bank/flows/epic-flow.md` | Canonical epic lifecycle governance | Owns package rules, layer model, gates and boundary rules | Add intake-only semantics without changing feature execution ownership |
+| `memory-bank/flows/templates/epic/charter.md` | Existing full epic intent template | Shows current frontmatter/body wrapper style | Keep full package canonical ownership separate |
+| `scripts/check_memory_bank_index.py` | Link/reachability/index audit | Acceptance requires index audit pass | Run after changes |
+
+## Test Strategy
+
+| Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites / commands | Required CI suites / jobs | Manual-only gap / justification | Manual-only approval ref |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Memory-bank link/index integrity | `REQ-06`, `SC-01`, `CHK-01` | `scripts/check_memory_bank_index.py` exists and currently passes | Re-run after docs changes | `python3 scripts/check_memory_bank_index.py` | Same audit if CI has it | none | `none` |
+| Source-project leakage in target docs | `REQ-05`, `NEG-01`, `CHK-03` | No dedicated test | Targeted `rg` check over changed template/governance docs | `rg -n "zelma|Zelma|dapi/zelma" ...` | none known | none | `none` |
+| Diff hygiene | `REQ-06`, `CHK-04` | Git built-in check | Run whitespace/conflict-marker check | `git diff --check` | Same if CI has it | none | `none` |
+| Semantic boundary review | `REQ-01`, `REQ-04`, `SC-02`, `CHK-02` | Manual documentation review | Review changed docs against issue acceptance and `design.md` invariants | Manual review plus grep/diff context | none known | Manual review is appropriate for prose semantics; backed by explicit `CHK-02` criteria | `none` |
+
+## Open Questions / Ambiguities
+
+| Open Question ID | Question | Why unresolved | Blocks | Default action / escalation owner |
+| --- | --- | --- | --- | --- |
+| `OQ-00` | None currently blocking execution | Issue scope, source template and current governance docs are sufficient | none | Continue; create human gate only if review finds materially ambiguous ownership |
+
+## Environment Contract
+
+| Area | Contract | Used by | Failure symptom |
+| --- | --- | --- | --- |
+| setup | Repo checkout at `feature/issue-14-epic-intake-brief-template` | `STEP-01`-`STEP-05` | Files or script paths missing |
+| test | Python 3 and ripgrep available | `STEP-05`, `CHK-01`, `CHK-03` | Audit or targeted search cannot run |
+| access / network / secrets | GitHub issue and source template already read through authenticated `gh` | `PRE-01` | Source evidence unavailable or contradictory |
+
+## Preconditions
+
+| Precondition ID | Canonical ref | Required state | Used by steps | Blocks start |
+| --- | --- | --- | --- | --- |
+| `PRE-01` | `ASM-01`, `CON-03`, `SD-01` | Issue 14 and source template inspected; target docs must stay generic | `STEP-01`, `STEP-02`, `STEP-03` | yes |
+| `PRE-02` | `C4-00`, `SD-03` | No C4 artifact or ADR required | `STEP-02`, `STEP-03` | no |
+
+## Workstreams
+
+| Workstream | Implements | Result | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| `WS-1` | `REQ-01`, `SOL-01`, `CTR-01` | New epic intake brief template | agent | `PRE-01` |
+| `WS-2` | `REQ-02`, `REQ-03`, `SOL-02`, `CTR-03` | Updated local and global template indexes | agent | `WS-1` |
+| `WS-3` | `REQ-04`, `SOL-03`, `CTR-02` | Updated `epic-flow.md` boundary and layer semantics | agent | `PRE-01` |
+| `WS-4` | `REQ-05`, `REQ-06`, `INV-01`, `FM-02`, `FM-03` | Verification evidence and review report | agent | `WS-1`, `WS-2`, `WS-3` |
+
+## Approval Gates
+
+| Approval Gate ID | Trigger | Applies to | Why approval is required | Approver / evidence |
+| --- | --- | --- | --- | --- |
+| `AG-00` | No risky external or irreversible action planned | none | Local Markdown edits and local checks do not require approval | `none` |
+
+## Порядок работ
+
+| Step ID | Actor | Implements | Goal | Touchpoints | Artifact | Verifies | Evidence IDs | Check command / procedure | Blocked by | Needs approval | Escalate if |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `STEP-01` | agent | `REQ-01`, `SOL-01`, `CTR-01` | Add generic epic intake brief wrapper-template | `memory-bank/flows/templates/epic/brief.md` | New template file | `CHK-02`, `CHK-03` | `EVID-02`, `EVID-03` | Review file content and targeted `rg` | `PRE-01` | `none` | Source-specific content is required to satisfy acceptance |
+| `STEP-02` | agent | `REQ-02`, `REQ-03`, `SOL-02`, `CTR-03` | Register new template in indexes | `memory-bank/flows/templates/epic/README.md`, `memory-bank/flows/templates/README.md` | Updated indexes | `CHK-01`, `CHK-02` | `EVID-01`, `EVID-02` | Link audit and review | `STEP-01` | `none` | Index audit requires unrelated index churn |
+| `STEP-03` | agent | `REQ-04`, `SOL-03`, `CTR-02` | Clarify epic intake boundaries | `memory-bank/flows/epic-flow.md` | Updated flow doc | `CHK-02` | `EVID-02` | Review boundary wording | `PRE-01` | `none` | Brief must become authoritative for roadmap/subissues/risks |
+| `STEP-04` | agent | `REQ-05`, `SOL-04`, `INV-01` | Remove or prevent source-specific leakage | Changed target docs | Clean target docs | `CHK-03` | `EVID-03` | Targeted `rg` | `STEP-01`, `STEP-03` | `none` | Source-specific term cannot be removed without losing acceptance |
+| `STEP-05` | agent | `REQ-06`, `RB-02` | Run final checks and record results | Repo root | Check outputs and review report | `CHK-01`, `CHK-04` | `EVID-01`, `EVID-04` | `python3 scripts/check_memory_bank_index.py`; `git diff --check` | `STEP-01`-`STEP-04` | `none` | Audit fails due unrelated pre-existing issues |
+
+## Parallelizable Work
+
+- `PAR-01` `STEP-01` and `STEP-03` can be drafted independently after `PRE-01`, but final wording must be reconciled before checks.
+- `PAR-02` Verification steps should run after all writes, because index reachability depends on the complete document graph.
+
+## Checkpoints
+
+| Checkpoint ID | Refs | Condition | Evidence IDs |
+| --- | --- | --- | --- |
+| `CP-01` | `STEP-01`, `STEP-02`, `STEP-03`, `CHK-02` | Changed docs satisfy issue acceptance and design invariants | `EVID-02` |
+| `CP-02` | `STEP-04`, `CHK-03` | No source-project terms in target template/governance docs | `EVID-03` |
+| `CP-03` | `STEP-05`, `CHK-01`, `CHK-04` | Link audit and diff hygiene pass | `EVID-01`, `EVID-04` |
+
+## Execution Risks
+
+| Risk ID | Risk | Impact | Mitigation | Trigger |
+| --- | --- | --- | --- | --- |
+| `ER-01` | Intake brief duplicates charter ownership | Confusing epic lifecycle | Keep `SD-01`, `CTR-02`, `INV-03` explicit in template and flow | Review finds brief owns roadmap or accepted subissues |
+| `ER-02` | New files become unreachable | Index audit failure | Update parent indexes before final audit | `CHK-01` fails with orphan/unreachable |
+| `ER-03` | Source-specific terms leak into generic docs | Violates issue scope | Run targeted `rg` over target docs | `CHK-03` finds matches |
+
+## Stop Conditions / Fallback
+
+| Stop ID | Related refs | Trigger | Immediate action | Safe fallback state |
+| --- | --- | --- | --- | --- |
+| `STOP-01` | `CON-01`, `SD-01`, `FM-01` | Review shows a material ambiguity over whether brief replaces charter/roadmap | Stop and create human gate | Keep current branch unmerged with findings recorded |
+| `STOP-02` | `CON-03`, `FM-02` | Required acceptance appears impossible without source-specific content | Stop and create human gate | No further template edits |
+
+## Plan-local Evidence
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checkpoints |
+| --- | --- | --- | --- | --- |
+| `EVID-09` | Review-improve report for feature docs | implementer / reviewer | `memory-bank/features/FT-014/feature-review-report.md` | `CP-01`, `CP-03` |
+
+## Готово для приемки
+
+- All workstreams are complete or explicitly stopped through `STOP-*`.
+- All checkpoints have evidence.
+- Required local suites are green, and CI does not contradict local verify.
+- Manual-only semantic review for `CHK-02` is recorded in `feature-review-report.md` or final delivery notes.
+- Final acceptance follows `brief.md` `Verify`, not this checklist.

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -29,3 +29,7 @@ audience: humans_and_agents
 - Базовый формат: `FT-XXX/`
 - Вместо `XXX` используй идентификатор, принятый в проекте: issue id, ticket id или другой стабильный ключ
 - Один package = одна delivery-единица
+
+## Packages
+
+- [`FT-014/`](FT-014/) — delivery package for issue 14: add lightweight epic intake brief template and related epic-flow/template index updates.

--- a/memory-bank/flows/epic-flow.md
+++ b/memory-bank/flows/epic-flow.md
@@ -2,7 +2,7 @@
 title: Epic Flow
 doc_kind: governance
 doc_function: canonical
-purpose: "Определяет lifecycle и качество epic-документации: charter, roadmap, decision log, risks, subissues и handoff в feature packages."
+purpose: "Определяет lifecycle и качество epic-документации: optional intake brief, charter, roadmap, decision log, risks, subissues и handoff в feature packages."
 derived_from:
   - ../dna/governance.md
   - ../dna/frontmatter.md
@@ -22,7 +22,7 @@ audience: humans_and_agents
 
 # Epic Flow
 
-Epic - это управляемая инициатива крупнее одной delivery-feature. Он задаёт общий intent, границы, roadmap, решения, риски и subissue registry, но не подменяет feature package и не содержит code-level execution plan.
+Epic - это управляемая инициатива крупнее одной delivery-feature. Он задаёт общий intent, границы, roadmap, решения, риски и subissue registry, но не подменяет feature package и не содержит code-level execution plan. До полного epic setup может существовать lightweight intake `brief.md`; он помогает зафиксировать proposal, но не становится owner-ом full epic governance.
 
 FPF-основание:
 
@@ -35,19 +35,21 @@ FPF-основание:
 
 1. Все документы одного epic живут в `memory-bank/epics/EP-XXX/`.
 2. `README.md` - routing layer и annotated index.
-3. `charter.md` - canonical owner intent: problem, outcome, scope/non-scope, stakeholder channels, source/evidence boundaries.
-4. `roadmap.md` - execution order owner: waves, gates, dependencies, stop rules and handoff protocol.
-5. `decision-log.md` - local decision ledger for decisions that affect the epic but do not require global ADR.
-6. `subissues.md` - registry of candidate and accepted delivery subissues, each mapped to roadmap waves and source `SLICE-*`/`UC-*`.
-7. `risks.md` - epic-level risk register for financial, operational, scope and delivery risks.
-8. `design.md`, `specs/**`, `diagrams/**`, `source-docs/**` — опциональные knowledge-артефакты. Они допустимы только когда индексируются из epic package и подчиняются правилам knowledge-артефактов ниже.
-9. `implementation-plan.md` не создаётся внутри epic. Code-level execution belongs to a separate `memory-bank/features/FT-<issue>/` package.
-10. Для canonical epic docs используй templates from `memory-bank/flows/templates/epic/`.
+3. `brief.md` - optional lightweight intake owner for early proposal facts: problem, outcome, rough scope/non-scope, candidate feature brief links and readiness notes before full epic setup. It is not authoritative after full owner docs exist.
+4. `charter.md` - canonical owner intent: problem, outcome, scope/non-scope, stakeholder channels, source/evidence boundaries.
+5. `roadmap.md` - execution order owner: waves, gates, dependencies, stop rules and handoff protocol.
+6. `decision-log.md` - local decision ledger for decisions that affect the epic but do not require global ADR.
+7. `subissues.md` - registry of candidate and accepted delivery subissues, each mapped to roadmap waves and source `SLICE-*`/`UC-*`.
+8. `risks.md` - epic-level risk register for financial, operational, scope and delivery risks.
+9. `design.md`, `specs/**`, `diagrams/**`, `source-docs/**` — опциональные knowledge-артефакты. Они допустимы только когда индексируются из epic package и подчиняются правилам knowledge-артефактов ниже.
+10. `implementation-plan.md` не создаётся внутри epic. Code-level execution belongs to a separate `memory-bank/features/FT-<issue>/` package.
+11. Для canonical epic docs используй templates from `memory-bank/flows/templates/epic/`.
 
 ## Layer Model
 
 | Layer | Primary docs | Owns | Must NOT define |
 | --- | --- | --- | --- |
+| Intake | `brief.md` | early proposal: problem, outcome, rough scope/non-scope, readiness notes, candidate feature brief links | authoritative roadmap, accepted subissues, risk controls, selected solution, feature acceptance contracts, implementation sequence |
 | Intent | `charter.md` | business/problem frame, scope, non-scope, source evidence, stakeholder channels | file paths, code steps, final implementation sequence |
 | Roadmap | `roadmap.md`, `subissues.md` | waves, dependencies, issue candidates, handoff gates | final code plan, exact migrations, test commands |
 | Governance | `decision-log.md`, `risks.md` | local decisions, risk controls, stop rules | global architecture policy unless promoted to ADR |
@@ -68,6 +70,7 @@ Knowledge-артефакты существуют только для норма
 
 ```mermaid
 flowchart LR
+    IB["Optional Intake<br/>brief.md draft"] --> DE["Draft Epic<br/>charter.md draft"]
     DE["Draft Epic<br/>charter.md draft"] --> ER["Epic Ready<br/>charter.md active"]
     ER --> RR["Roadmap Ready<br/>roadmap/subissues/risks active"]
     RR --> EX["Execution<br/>delivery features created"]
@@ -78,6 +81,14 @@ flowchart LR
 ```
 
 ## Transition Gates
+
+### Optional Intake Brief
+
+- [ ] `brief.md` создан по шаблону `templates/epic/brief.md`
+- [ ] `brief.md` фиксирует problem, outcome, rough scope, non-scope и readiness notes
+- [ ] `brief.md` не определяет roadmap waves, accepted subissues, risk controls, selected solution, feature acceptance contracts или implementation sequence
+- [ ] если full epic owner docs уже существуют, `brief.md` не противоречит им или явно помечает intake facts как superseded by full owners
+- [ ] `implementation-plan.md` отсутствует
 
 ### Bootstrap Epic
 
@@ -130,6 +141,8 @@ Epic quality is a Q-Bundle, not one scalar.
 
 | Prefix | Meaning | Owner |
 | --- | --- | --- |
+| `BR-REQ-*` | Intake rough scope item | optional `brief.md` |
+| `BR-NS-*` | Intake rough non-scope item | optional `brief.md` |
 | `EP-SI-*` | Epic subissue candidate or accepted subissue | `subissues.md` |
 | `W*` | Roadmap wave | `roadmap.md` |
 | `HG-*` | Handoff gate before feature execution | `roadmap.md` |
@@ -144,3 +157,5 @@ Epic quality is a Q-Bundle, not one scalar.
 3. Epic may close local decisions with FPF and evidence. If a decision changes global project architecture, create ADR.
 4. Feature package, созданный из epic, должен ссылаться на релевантные `EP-*` docs и сохранять stable IDs вместо копирования всего scope. `brief.md` импортирует problem/scope refs; `design.md` или ADR импортирует epic-local decisions, когда они влияют на solution space.
 5. If a feature discovers a new epic-level fact, update the epic owner document first, then update the feature.
+6. Optional epic intake `brief.md` may exist before full setup, but it does not replace `charter.md`, `roadmap.md`, `subissues.md`, `risks.md` or `decision-log.md`; if facts mature or conflict, update the appropriate full owner.
+7. Optional epic intake `brief.md` must not define implementation sequence. Execution planning belongs to feature packages under `memory-bank/features/FT-<issue>/`.

--- a/memory-bank/flows/templates/README.md
+++ b/memory-bank/flows/templates/README.md
@@ -8,6 +8,7 @@ derived_from:
   - prd/PRD-XXX.md
   - use-case/UC-XXX.md
   - epic/README.md
+  - epic/brief.md
   - epic/charter.md
   - epic/roadmap.md
   - epic/decision-log.md
@@ -37,6 +38,7 @@ audience: humans_and_agents
 - [PRD-XXX: Product Initiative Name](prd/PRD-XXX.md) — компактный Product Requirements Document для инициативы, которая еще не разложена на один конкретный feature slice.
 - [UC-XXX: Use Case Name](use-case/UC-XXX.md) — канонический use case для устойчивого пользовательского или операционного сценария.
 - [Epic Templates](epic/README.md) — индекс шаблонов `EP-XXX` package.
+- [EP-XXX: Brief Template](epic/brief.md) — lightweight intake template для early epic proposal до полного setup. Отвечает на вопрос: как зафиксировать problem, outcome, rough scope, non-scope и readiness notes без подмены charter/roadmap.
 - [EP-XXX: Charter Template](epic/charter.md) — intent, scope, source/evidence and stakeholder channels.
 - [EP-XXX: Roadmap Template](epic/roadmap.md) — waves, dependencies, gates and stop rules.
 - [EP-XXX: Decision Log Template](epic/decision-log.md) — local epic decisions that do not require global ADR.

--- a/memory-bank/flows/templates/epic/README.md
+++ b/memory-bank/flows/templates/epic/README.md
@@ -2,7 +2,7 @@
 title: Epic Templates Index
 doc_kind: governance
 doc_function: template
-purpose: "Wrapper-шаблоны для `memory-bank/epics/EP-XXX/` packages: charter, roadmap, decision log, subissues and risks."
+purpose: "Wrapper-шаблоны для `memory-bank/epics/EP-XXX/` packages: lightweight intake brief, charter, roadmap, decision log, subissues and risks."
 derived_from:
   - ../../epic-flow.md
 status: active
@@ -11,8 +11,9 @@ audience: humans_and_agents
 
 # Epic Templates Index
 
-Используй эти templates при создании нового `memory-bank/epics/EP-XXX/`.
+Используй эти templates при создании нового `memory-bank/epics/EP-XXX/`. `brief.md` допустим как легкий intake до полного setup; authoritative package owners остаются в `charter.md`, `roadmap.md`, `decision-log.md`, `subissues.md` и `risks.md`.
 
+- [`brief.md`](brief.md) - lightweight intake proposal: problem, outcome, rough scope, non-scope and readiness notes before full epic setup.
 - [`charter.md`](charter.md) - intent, scope, source/evidence and stakeholder channels.
 - [`roadmap.md`](roadmap.md) - waves, dependencies, gates and stop rules.
 - [`decision-log.md`](decision-log.md) - local epic decisions that do not require global ADR.

--- a/memory-bank/flows/templates/epic/brief.md
+++ b/memory-bank/flows/templates/epic/brief.md
@@ -1,0 +1,83 @@
+---
+title: "EP-XXX: Brief Template"
+doc_kind: governance
+doc_function: template
+purpose: "Wrapper-шаблон для lightweight epic intake brief. Используется до полного epic setup и не заменяет charter, roadmap, subissues, risks или decision log."
+derived_from:
+  - ../../epic-flow.md
+status: active
+audience: humans_and_agents
+template_for: epic
+template_target_path: ../../../epics/EP-XXX/brief.md
+---
+
+# EP-XXX: Brief Template
+
+## Wrapper Notes
+
+Используй этот template, когда инициативу нужно быстро зафиксировать как epic proposal до полного package setup. `brief.md` помогает записать problem, outcome, rough scope, non-scope и readiness notes, но не становится authoritative owner-ом полного epic.
+
+Когда initiative готова к full setup, создай canonical `charter.md`, `roadmap.md`, `subissues.md`, `risks.md` и, если нужны локальные решения, `decision-log.md`. Если intake brief и full epic owner конфликтуют, full owner должен быть обновлен или создан, а brief остается только intake context.
+
+## Instantiated Frontmatter
+
+```yaml
+---
+title: "EP-XXX: Brief"
+doc_kind: epic
+doc_function: brief
+purpose: "Lightweight intake brief для epic proposal: problem, outcome, rough scope, non-scope и readiness notes до полного epic setup."
+derived_from:
+  - ../../flows/epic-flow.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - roadmap_waves
+  - accepted_subissues
+  - risk_controls
+  - selected_solution
+  - feature_acceptance_contracts
+---
+```
+
+## Instantiated Body
+
+```markdown
+# EP-XXX: Brief
+
+## Problem
+
+Почему эта инициатива нужна и какой gap она закрывает.
+
+## Outcome
+
+Какой наблюдаемый результат должен появиться после исполнения epic.
+
+## Rough Scope
+
+- `BR-REQ-01` Что предварительно входит в инициативу.
+
+## Non-Scope
+
+- `BR-NS-01` Что не должно попадать в инициативу.
+
+## Candidate Feature Briefs
+
+- [FT-XXX: Feature Name](../../features/FT-XXX/README.md)
+
+## Readiness Notes
+
+- Что нужно уточнить до полного `charter.md` / `roadmap.md` / `subissues.md` / `risks.md`.
+- Какие source materials, stakeholder answers or constraints still need evidence.
+
+## Full Epic Package Handoff
+
+Before execution, promote or supersede intake facts in the full epic package:
+
+- `charter.md` owns authoritative problem, outcome, scope, non-scope and evidence boundaries.
+- `roadmap.md` owns waves, dependencies, gates and stop rules.
+- `subissues.md` owns accepted delivery subissues.
+- `risks.md` owns epic-level risks and controls.
+- Feature execution belongs to `memory-bank/features/FT-<issue>/`.
+```


### PR DESCRIPTION
## Summary

- Add `memory-bank/flows/templates/epic/brief.md` as a lightweight epic intake template.
- Update epic template indexes so the new template is discoverable.
- Clarify `epic-flow.md` boundaries: intake brief does not replace charter/roadmap/subissues/risks and does not own implementation sequencing.
- Add FT-014 feature package with brief, design, implementation plan, decision log, and review-improve report.

## Validation

- `python3 scripts/check_memory_bank_index.py`
- `git diff --check`
- `rg -n "zelma|Zelma|dapi/zelma" memory-bank/flows/templates/epic/brief.md memory-bank/flows/templates/epic/README.md memory-bank/flows/templates/README.md memory-bank/flows/epic-flow.md` returned no matches.

## Issue

Refs #14