### PR TITLE
[codex] Describe operational agentic use cases

### DIFF
--- a/artifacts/ft-015/verify/chk-01.md
+++ b/artifacts/ft-015/verify/chk-01.md
@@ -1,0 +1,25 @@
+# CHK-01: README Guidance Coverage
+
+Command:
+
+```sh
+rg -n "Operational|agentic|machine-readable|recovery|postconditions|SC-\\*" memory-bank/use-cases/README.md
+```
+
+Result: pass.
+
+Relevant output:
+
+```text
+17:Use case нужен для сценария, который живет на уровне продукта, повторяется во времени и может быть upstream для нескольких feature packages. Это не замена `SC-*` внутри `brief.md`: `SC-*` описывают acceptance сценарии delivery-единицы, а `UC-*` описывают устойчивое поведение системы на уровне проекта.
+25:- нужен канонический owner для trigger, preconditions, main flow и postconditions.
+31:- его достаточно описать через `SC-*` в `brief.md`.
+33:## Operational / Agentic Use Cases
+35:Operational и agentic use cases описывают устойчивые рабочие сценарии, где
+45:  postconditions;
+47:- задает machine-readable contract, status или handoff format, который другие
+49:- описывает recovery/postconditions, которые важны независимо от конкретной
+52:Оставляй сценарий в feature-level `SC-*`, если он нужен только для приемки
+56:Machine-readable status, structured diagnostics, handoff payloads, recovery
+57:outcomes и postconditions допустимо описывать в `UC-*`, когда они являются
+```

--- a/artifacts/ft-015/verify/chk-02.md
+++ b/artifacts/ft-015/verify/chk-02.md
@@ -1,0 +1,10 @@
+# CHK-02: Source-Specific Leakage Guard
+
+Command:
+
+```sh
+rg -n "zelma|zellij|Codex|sessions list|setup --json" memory-bank/use-cases/README.md
+```
+
+Result: pass. The command returned exit code `1` with no matches, which is the
+expected result for this negative check.

--- a/artifacts/ft-015/verify/chk-03.md
+++ b/artifacts/ft-015/verify/chk-03.md
@@ -1,0 +1,39 @@
+# CHK-03: Template Compatibility and Repository Hygiene
+
+Semantic compatibility review: pass.
+
+`memory-bank/use-cases/README.md` now explains when operational/agentic
+scenarios should become project-level `UC-*` versus feature-level `SC-*`.
+`memory-bank/flows/templates/use-case/UC-XXX.md` already provides the required
+shape for this guidance: goal, primary actor, trigger, preconditions, main flow,
+alternate flows / exceptions, postconditions, business rules, and traceability.
+No `UC-XXX` template change is required.
+
+Command:
+
+```sh
+python3 scripts/check_memory_bank_index.py
+```
+
+Result: pass.
+
+Relevant output:
+
+```text
+OK: no broken internal markdown links in scope.
+OK: no broken frontmatter markdown dependencies in scope.
+OK: no orphan markdown files in scope.
+OK: all scoped markdown files are reachable from the configured entrypoints via index navigation.
+OK: no documents are reachable only deeper than the configured threshold.
+Index compliance:
+  - OK
+Result: OK
+```
+
+Command:
+
+```sh
+git diff --check
+```
+
+Result: pass. The command produced no output.

--- a/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/README.md
+++ b/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/README.md
@@ -1,0 +1,37 @@
+---
+title: "FT-015: Operational and Agentic Use Cases Pattern"
+doc_kind: feature
+doc_function: index
+purpose: "Bootstrap-safe navigation for FT-015. Read this first to route to canonical problem, execution plan, and feature-local decisions."
+derived_from:
+  - ../../dna/governance.md
+  - brief.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-015: Operational and Agentic Use Cases Pattern
+
+## О разделе
+
+Каталог feature package описывает delivery-единицу для GitHub issue
+[#15](https://github.com/dapi/memory-bank/issues/15): добавить generic guidance
+для operational/agentic use cases без переноса downstream-specific деталей.
+
+## Аннотированный индекс
+
+- [`brief.md`](brief.md)
+  Читать, когда нужно: проверить problem space, scope, non-scope и canonical verify contract.
+  Отвечает на вопрос: что именно должна изменить эта delivery-единица и как это принимается.
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Читать, когда нужно: выполнить изменение по шагам, проверить evidence и локальные gates.
+  Отвечает на вопрос: как провести реализацию без переопределения требований из `brief.md`.
+
+- [`decision-log.md`](decision-log.md)
+  Читать, когда нужно: проверить feature-local решения, закрытые через FPF reasoning.
+  Отвечает на вопрос: какие существенные развилки были закрыты по текущим фактам.
+
+- [`feature-review-report.md`](feature-review-report.md)
+  Читать, когда нужно: проверить результат bounded review-improve циклов по feature-документам.
+  Отвечает на вопрос: какие critical/important замечания были найдены, исправлены или оставлены.

--- a/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/brief.md
+++ b/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/brief.md
@@ -1,0 +1,128 @@
+---
+title: "FT-015: Operational and Agentic Use Cases Pattern"
+doc_kind: feature
+doc_function: canonical
+purpose: "Canonical brief for adding generic guidance about operational and agentic use cases without mixing project-specific source examples into the template."
+derived_from:
+  - ../../flows/feature-flow.md
+  - ../../use-cases/README.md
+  - ../../flows/templates/use-case/UC-XXX.md
+status: active
+delivery_status: in_progress
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - solution_space
+source_issue: "https://github.com/dapi/memory-bank/issues/15"
+---
+
+# FT-015: Operational and Agentic Use Cases Pattern
+
+## What
+
+### Problem
+
+`memory-bank/use-cases/README.md` already says that use cases can describe
+project-level operational scenarios, but it does not explicitly explain the
+operational/agentic class called out by issue
+[#15](https://github.com/dapi/memory-bank/issues/15): handoff, recovery,
+parallel delivery, environment diagnostics, and machine-readable status.
+
+The downstream source examples named in the issue show real `UC-*` files for
+this class, but they are project-specific evidence. The generic template needs
+the pattern, not source project names, tool names, commands, runtime
+assumptions, or vendor-specific workflows.
+
+### Outcome
+
+| Metric ID | Metric | Baseline | Target | Measurement method |
+| --- | --- | --- | --- | --- |
+| `MET-01` | Generic operational/agentic guidance coverage | README explains general use cases but not the explicit operational/agentic class from issue #15 | README contains reusable guidance for operational/agentic workflows, UC-vs-SC routing, machine-readable contracts, and recovery/postconditions | `CHK-01`, `CHK-03` |
+| `MET-02` | Template genericity | Source examples include downstream-specific tool/runtime details | Updated generic docs contain no source project terms, tool names, runtime details, or command examples | `CHK-02` |
+
+### Scope
+
+- `REQ-01` Update `memory-bank/use-cases/README.md` with a generic section for operational and agentic use cases.
+- `REQ-02` Add guidance for when an operational/agentic scenario should become a project-level `UC-*` versus when feature-level `SC-*` is enough.
+- `REQ-03` State that machine-readable status/contracts and recovery/postconditions can be described as use cases when they are stable project-level behavior.
+- `REQ-04` Verify that the existing `UC-XXX` template does not conflict with the new guidance.
+
+### Non-Scope
+
+- `NS-01` Do not add instantiated `UC-*` files for this template repository.
+- `NS-02` Do not add downstream-specific source content, including source project names, tool names, vendor-specific workflows, CLI commands, or project-specific runtime assumptions.
+- `NS-03` Do not change the `UC-XXX` template unless a concrete conflict with the new README guidance is found.
+- `NS-04` Do not change feature-flow, epic-flow, PRD, ADR, product, domain, or ops rules.
+
+### Constraints / Assumptions
+
+- `ASM-01` GitHub issue #15 is the source task and defines the required scope and acceptance.
+- `ASM-02` Downstream source documents named in issue #15 are evidence of the pattern class, not reusable generic content.
+- `CON-01` This repository is a generic memory-bank template; downstream project-specific specialization must not be copied into `memory-bank/`.
+- `CON-02` `memory-bank/use-cases/README.md` owns index-level guidance for when to create a use case; `memory-bank/flows/templates/use-case/UC-XXX.md` owns the canonical instantiated use case shape.
+
+## Design Requirement Decision
+
+| Decision | Reason | Downstream owner |
+| --- | --- | --- |
+| `Design required: no` | The feature changes Markdown guidance only. It does not alter API, schema, file format, runtime, security, integration, rollout/backout, or architecture boundaries; no solution-space trade-off owner is needed. | `none` |
+
+## Verify
+
+### Exit Criteria
+
+- `EC-01` `memory-bank/use-cases/README.md` contains operational/agentic guidance that is reusable for any agentic or ops workflow.
+- `EC-02` The README distinguishes project-level `UC-*` from feature-level `SC-*` for operational/agentic scenarios.
+- `EC-03` The README explicitly allows machine-readable contracts/status, recovery behavior, and postconditions to be modeled as use cases when they are stable project-level behavior.
+- `EC-04` The updated text contains no downstream-specific terms or commands from the source examples.
+- `EC-05` The existing `UC-XXX` template remains compatible with the new README guidance.
+
+### Traceability matrix
+
+| Requirement ID | Problem refs | Acceptance refs | Checks | Evidence IDs |
+| --- | --- | --- | --- | --- |
+| `REQ-01` | `ASM-01`, `ASM-02`, `CON-01` | `EC-01`, `SC-01` | `CHK-01`, `CHK-03` | `EVID-01`, `EVID-03` |
+| `REQ-02` | `ASM-01`, `CON-02` | `EC-02`, `SC-01`, `SC-02` | `CHK-01`, `CHK-03` | `EVID-01`, `EVID-03` |
+| `REQ-03` | `ASM-01`, `ASM-02` | `EC-03`, `SC-01` | `CHK-01`, `CHK-03` | `EVID-01`, `EVID-03` |
+| `REQ-04` | `CON-02`, `NS-03` | `EC-05`, `SC-03` | `CHK-03` | `EVID-03` |
+
+### Acceptance Scenarios
+
+- `SC-01` A reader evaluating repeated operational handoff, recovery, diagnostics, or status-reporting behavior can tell that it may become `UC-*` when it is stable project-level behavior.
+- `SC-02` A reader evaluating a one-off delivery acceptance scenario can tell that it should remain `SC-*` in the relevant feature `brief.md`.
+- `SC-03` A reviewer compares the new README section with the `UC-XXX` template and finds no conflicting ownership or required fields.
+
+### Negative / Edge Cases
+
+- `NEG-01` If the updated README mentions source-specific project names, tool names, command examples, or runtime details from the downstream examples, reject the change.
+- `NEG-02` If the guidance implies that every operational check must become `UC-*` regardless of stability, repetition, or project-level ownership, reject the change.
+
+### Checks
+
+| Check ID | Covers | How to check | Expected result | Evidence path |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `EC-01`, `EC-02`, `EC-03`, `SC-01`, `SC-02` | `rg -n "Operational|agentic|machine-readable|recovery|postconditions|SC-\\*" memory-bank/use-cases/README.md` | Output shows the new generic guidance and UC-vs-SC routing. | `artifacts/ft-015/verify/chk-01.md` |
+| `CHK-02` | `EC-04`, `NEG-01` | Run a forbidden-term `rg` check for the source project names, tool names, and command fragments listed in issue #15 against `memory-bank/use-cases/README.md`. | No matches. | `artifacts/ft-015/verify/chk-02.md` |
+| `CHK-03` | `EC-05`, `SC-03`, `NEG-02` | Review `memory-bank/use-cases/README.md` and `memory-bank/flows/templates/use-case/UC-XXX.md`; then run `python3 scripts/check_memory_bank_index.py` and `git diff --check`. | README guidance does not conflict with the template, index audit passes, and diff check is clean. | `artifacts/ft-015/verify/chk-03.md` |
+
+### Test matrix
+
+| Check ID | Evidence IDs | Evidence path |
+| --- | --- | --- |
+| `CHK-01` | `EVID-01` | `artifacts/ft-015/verify/chk-01.md` |
+| `CHK-02` | `EVID-02` | `artifacts/ft-015/verify/chk-02.md` |
+| `CHK-03` | `EVID-03` | `artifacts/ft-015/verify/chk-03.md` |
+
+### Evidence
+
+- `EVID-01` Output proving the README contains the new generic operational/agentic guidance.
+- `EVID-02` Output proving downstream-specific source terms are absent from the updated README.
+- `EVID-03` Output or reviewer note proving the README, `UC-XXX` template, memory-bank index audit, and whitespace/conflict-marker checks are clean.
+
+### Evidence contract
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checks |
+| --- | --- | --- | --- | --- |
+| `EVID-01` | Command output or note for README guidance coverage | implementer | `artifacts/ft-015/verify/chk-01.md` | `CHK-01` |
+| `EVID-02` | Command output for forbidden source-specific terms | implementer | `artifacts/ft-015/verify/chk-02.md` | `CHK-02` |
+| `EVID-03` | Validation output and compatibility note | implementer / reviewer | `artifacts/ft-015/verify/chk-03.md` | `CHK-03` |

--- a/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/brief.md
+++ b/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/brief.md
@@ -8,7 +8,7 @@ derived_from:
   - ../../use-cases/README.md
   - ../../flows/templates/use-case/UC-XXX.md
 status: active
-delivery_status: in_progress
+delivery_status: done
 audience: humans_and_agents
 must_not_define:
   - implementation_sequence

--- a/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/decision-log.md
+++ b/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/decision-log.md
@@ -1,0 +1,27 @@
+---
+title: "FT-015: Decision Log"
+doc_kind: feature
+doc_function: decision_log
+purpose: "Feature-local decision log for FPF-backed decisions that do not require ADRs."
+derived_from:
+  - brief.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-015: Decision Log
+
+This log records feature-local decisions closed from the current document set and
+source issue. It does not create project-wide architecture decisions.
+
+## Decisions
+
+| Decision ID | Status | Question | Decision | Facts used | FPF reasoning | Consequences |
+| --- | --- | --- | --- | --- | --- | --- |
+| `DL-001` | accepted | Does FT-015 require `design.md`? | No. Keep `Design required: no` in `brief.md`. | Issue #15 asks for generic README guidance; `feature-flow.md` requires design for API/schema/runtime/contract/security/integration or solution trade-off changes; none are in scope. | A.7 Strict Distinction keeps problem/verify, solution, and execution owners separate. B.5 reasoning: the hypothesis "README-only guidance is enough" predicts no solution-space contract is needed; feature-flow gates confirm that prediction. | No `design.md` is created. `implementation-plan.md` may proceed after active `brief.md`. |
+| `DL-002` | accepted | Should source examples create generic `UC-*` files or change the `UC-XXX` template? | No by default. Update only `memory-bank/use-cases/README.md` unless a concrete template conflict is found. | Issue #15 scope names README update and acceptance says `UC-XXX` template must not conflict. Current `UC-XXX` template already has trigger, preconditions, main flow, alternates, postconditions, business rules, and traceability. | A.10 Evidence Graph Referring treats source examples as carriers for pattern evidence, not as generic content to copy. A.7 separates the index/guidance owner (`README.md`) from the template shape owner (`UC-XXX.md`). | No instantiated `UC-*` files are added. Template remains unchanged unless `CHK-03` proves a conflict. |
+| `DL-003` | accepted | Can machine-readable status/contracts, recovery, and postconditions be first-class use case content? | Yes, when they describe stable project-level operational behavior rather than one-off feature acceptance. | Issue #15 explicitly asks to fix this. Current README already says use cases may be operational and project-level, and `SC-*` remains feature-level acceptance. Source examples demonstrate repeated handoff, parallel delivery, and diagnostics flows. | A.13 models agency as a role played by a system in context, so agentic workflows can be described generically without creating a special "agent" document type. A.7 keeps actual execution and evidence carriers distinct, so machine-readable contracts/status can be observable parts of the scenario rather than implementation details. | README guidance should mention machine-readable contracts/status, recovery behavior, and postconditions while preserving the `UC-*` vs `SC-*` boundary. |
+
+## Human Gates
+
+None currently open.

--- a/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/feature-review-report.md
+++ b/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/feature-review-report.md
@@ -1,0 +1,145 @@
+---
+title: "FT-015: Feature Documents Review Report"
+doc_kind: feature-support
+doc_function: reference
+purpose: "Final bounded review-improve report for the FT-015 feature document package."
+derived_from:
+  - brief.md
+  - implementation-plan.md
+  - decision-log.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-015: Feature Documents Review Report
+
+## Scope
+
+Reviewed package:
+
+- `README.md`
+- `brief.md`
+- `implementation-plan.md`
+- `decision-log.md`
+- `feature-review-report.md`
+- related index artifact: `../README.md`
+
+Related upstream/source artifacts:
+
+- GitHub issue #15
+- `memory-bank/flows/feature-flow.md`
+- `memory-bank/dna/frontmatter.md`
+- `memory-bank/dna/governance.md`
+- `memory-bank/use-cases/README.md`
+- `memory-bank/flows/templates/use-case/UC-XXX.md`
+
+## Cycle 1
+
+### Review summary
+
+The feature package did not exist, so the issue could not be worked through
+feature-flow. This blocked lifecycle ownership, traceability, verify contract,
+and downstream execution planning.
+
+### Critical and important findings
+
+| Priority | Finding | Resolution |
+| --- | --- | --- |
+| `critical` | Missing feature package for issue #15. | Created `FT-015-pattern-operational-agentic-use-cases/`. |
+| `critical` | Missing canonical `brief.md`, so problem space, scope, non-scope, assumptions, constraints, and verify contract had no owner. | Created `brief.md` with `status: active` and `delivery_status: planned`. |
+| `important` | Missing execution plan after `Design required: no`; implementation sequencing and checks had no owner. | Created `implementation-plan.md` with `status: active`. |
+| `important` | Missing feature-local decision log requested by the review-improve instructions. | Created `decision-log.md`. |
+
+### FPF-closed questions
+
+- `DL-001`: closed whether `design.md` is required. Decision: no, because the feature is Markdown guidance only and does not cross solution-space triggers from `feature-flow.md`.
+- `DL-002`: closed whether source examples should create generic `UC-*` files or change the `UC-XXX` template. Decision: no by default; update README guidance unless a template conflict is proven.
+- `DL-003`: closed whether machine-readable status/contracts, recovery, and postconditions can be use case content. Decision: yes, when stable and project-level.
+
+### Changes made
+
+- Added feature `README.md`.
+- Added canonical `brief.md`.
+- Added derived `implementation-plan.md`.
+- Added feature-local `decision-log.md`.
+
+### Human gate
+
+No.
+
+## Cycle 2
+
+### Review summary
+
+The package existed, but review found consistency and reachability issues that
+would materially reduce document readiness.
+
+### Critical and important findings
+
+| Priority | Finding | Resolution |
+| --- | --- | --- |
+| `important` | Feature documents repeated downstream-specific source terms instead of treating source examples only as evidence. | Reworded feature docs to refer to downstream examples generically and removed source-specific terms. |
+| `important` | `python3 scripts/check_memory_bank_index.py` reported the new package as orphaned because `memory-bank/features/README.md` did not link to it. | Added `FT-015` to the feature package registry in `memory-bank/features/README.md`. |
+| `important` | The plan described semantic template compatibility as a manual-only gap while also saying no approval was needed. | Reworded it as a documented `CHK-03` review procedure, not a manual-only approval gap. |
+
+### FPF-closed questions
+
+No new blocking questions were closed. Cycle 2 applied the owner-boundary
+decisions already recorded in `DL-001` through `DL-003`.
+
+### Changes made
+
+- Updated `brief.md`, `implementation-plan.md`, and `decision-log.md` wording for genericity.
+- Updated `memory-bank/features/README.md` registry.
+
+### Human gate
+
+No.
+
+## Cycle 3
+
+### Review summary
+
+No remaining `critical` or `important` findings were found in the feature
+document package. The documents are consistent with feature-flow boundaries:
+`brief.md` owns problem and verify, no `design.md` is required, the plan owns
+execution, and `decision-log.md` owns feature-local FPF decisions.
+
+### Critical and important findings
+
+None.
+
+### FPF-closed questions
+
+None.
+
+### Changes made
+
+- Added this final review report and linked it from package `README.md`.
+
+### Human gate
+
+No.
+
+## Final Status
+
+| Field | Value |
+| --- | --- |
+| Status | `done` |
+| Cycles executed | `3` |
+| Human gate | `no` |
+| Decision log | `decision-log.md` |
+
+## Closed Findings
+
+- Missing feature package and lifecycle owners.
+- Missing canonical `brief.md`.
+- Missing `implementation-plan.md`.
+- Missing feature-local `decision-log.md`.
+- Source-specific leakage in feature docs.
+- Missing feature package registry link.
+- Ambiguous manual-only wording in test strategy.
+
+## Remaining Critical / Important Findings
+
+None.

--- a/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/implementation-plan.md
+++ b/memory-bank/features/FT-015-pattern-operational-agentic-use-cases/implementation-plan.md
@@ -1,0 +1,135 @@
+---
+title: "FT-015: Implementation Plan"
+doc_kind: feature
+doc_function: derived
+purpose: "Execution plan for FT-015. Captures discovery context, steps, risks, and test strategy without redefining scope or acceptance."
+derived_from:
+  - brief.md
+status: archived
+audience: humans_and_agents
+must_not_define:
+  - ft_015_scope
+  - ft_015_selected_design
+  - ft_015_acceptance_criteria
+  - ft_015_blocker_state
+---
+
+# План имплементации
+
+## Цель текущего плана
+
+Выполнить Markdown-only изменение по `brief.md`: обновить
+`memory-bank/use-cases/README.md` generic guidance для operational/agentic use
+cases, не добавляя project-specific source content и не меняя `UC-XXX`
+template без обнаруженного конфликта.
+
+## Grounding / Support References
+
+| Document | Role in this plan | Facts reused | Conflict action |
+| --- | --- | --- | --- |
+| `brief.md` | canonical problem / verify owner | `REQ-*`, `NS-*`, `SC-*`, `CHK-*`, `EVID-*` | Update `brief.md` first |
+| `design.md` / `none` | conditional solution owner | `Design required: no` | Promote new design facts before planning |
+| `decision-log.md` | feature-local decision log | `DL-*` FPF decisions for owner boundaries and source abstraction | Update `decision-log.md` if a new material decision is closed |
+
+## Current State / Reference Points
+
+| Path / module | Current role | Why relevant | Reuse / mirror |
+| --- | --- | --- | --- |
+| `memory-bank/use-cases/README.md` | Use case index and guidance | Primary change surface for `REQ-01` through `REQ-03` | Preserve current UC-vs-SC distinction and registry format |
+| `memory-bank/flows/templates/use-case/UC-XXX.md` | Canonical use case template | Must remain compatible with new guidance per `REQ-04` | Reuse existing trigger, preconditions, main flow, alternate flows, postconditions, rules, and traceability shape |
+| `memory-bank/flows/feature-flow.md` | Feature package lifecycle and ID taxonomy | Defines document boundaries, design gate, and verify requirements | Keep `brief.md` as problem/verify owner and plan as execution owner |
+| GitHub issue #15 | Source task | Defines scope, source examples, and acceptance constraints | Use as external source of task intent only |
+| Downstream source use cases named in issue #15 | Pattern evidence | Shows operational/agentic use cases in a downstream project | Abstract pattern only; do not copy project names, tool names, commands, or runtime specifics |
+
+## Test Strategy
+
+| Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites / commands | Required CI suites / jobs | Manual-only gap / justification | Manual-only approval ref |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| README guidance content | `REQ-01`, `REQ-02`, `REQ-03`, `SC-01`, `SC-02`, `CHK-01` | No explicit operational/agentic section | `rg` coverage check for generic terms and routing language | `rg -n "Operational|agentic|machine-readable|recovery|postconditions|SC-\\*" memory-bank/use-cases/README.md` | repository default doc checks if configured | none | `none` |
+| Genericity guard | `NS-02`, `NEG-01`, `CHK-02` | No source content currently present | Negative `rg` check for source-specific terms listed in issue #15 | Run forbidden-term `rg` against `memory-bank/use-cases/README.md` | repository default doc checks if configured | none | `none` |
+| Governance / index health | `REQ-04`, `CHK-03` | `scripts/check_memory_bank_index.py` exists | Existing memory-bank index audit and diff whitespace check | `python3 scripts/check_memory_bank_index.py`; `git diff --check` | repository default doc checks if configured | none; semantic compatibility review is the documented `CHK-03` procedure | `none` |
+
+## Open Questions / Ambiguities
+
+| Open Question ID | Question | Why unresolved | Blocks | Default action / escalation owner |
+| --- | --- | --- | --- | --- |
+| `OQ-00` | None currently open. | Existing facts are sufficient for this Markdown-only guidance change. | none | Reopen if implementation reveals a conflict between README guidance and `UC-XXX` template. |
+
+## Environment Contract
+
+| Area | Contract | Used by | Failure symptom |
+| --- | --- | --- | --- |
+| setup | Work from repository root with shell access. | `STEP-01` through `STEP-04` | Paths under `memory-bank/` cannot be read or edited. |
+| test | Use `rg`, `python3 scripts/check_memory_bank_index.py`, and `git diff --check`. | `CHK-01`, `CHK-02`, `CHK-03` | Missing tool, failing index audit, or dirty whitespace/conflict markers. |
+| access / network / secrets | No secrets required. Network is useful only for reading issue/source examples; implementation itself is local. | `STEP-01` | If external source is unavailable, continue from issue facts already captured in `brief.md`; do not invent additional source facts. |
+
+## Preconditions
+
+| Precondition ID | Canonical ref | Required state | Used by steps | Blocks start |
+| --- | --- | --- | --- | --- |
+| `PRE-01` | `brief.md` Design Requirement Decision | `Design required: no` and `status: active` | `STEP-01` through `STEP-04` | yes |
+| `PRE-02` | `NS-02`, `CON-01` | Source-specific details remain excluded from generic docs | `STEP-02`, `STEP-03` | yes |
+
+## Workstreams
+
+| Workstream | Implements | Result | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| `WS-1` | `REQ-01`, `REQ-02`, `REQ-03` | Updated `memory-bank/use-cases/README.md` guidance | agent | `PRE-01`, `PRE-02` |
+| `WS-2` | `REQ-04` | Compatibility verdict for `UC-XXX` template | agent | `WS-1` |
+| `WS-3` | `CHK-01`, `CHK-02`, `CHK-03` | Local verification evidence | agent | `WS-1`, `WS-2` |
+
+## Approval Gates
+
+| Approval Gate ID | Trigger | Applies to | Why approval is required | Approver / evidence |
+| --- | --- | --- | --- | --- |
+| `AG-00` | None. | none | The planned change is local Markdown guidance with no external side effects. | `none` |
+
+## Порядок работ
+
+| Step ID | Actor | Implements | Goal | Touchpoints | Artifact | Verifies | Evidence IDs | Check command / procedure | Blocked by | Needs approval | Escalate if |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `STEP-01` | agent | `REQ-01`, `REQ-02`, `REQ-03` | Add generic operational/agentic use case guidance and UC-vs-SC routing. | `memory-bank/use-cases/README.md` | README diff | `CHK-01` | `EVID-01` | `rg -n "Operational|agentic|machine-readable|recovery|postconditions|SC-\\*" memory-bank/use-cases/README.md` | `PRE-01`, `PRE-02` | `none` | Required guidance cannot be stated without project-specific terms. |
+| `STEP-02` | agent | `NS-02`, `NEG-01` | Remove any source-specific leakage. | `memory-bank/use-cases/README.md` | README diff | `CHK-02` | `EVID-02` | Run forbidden-term `rg` for source-specific project/tool names and command fragments listed in issue #15 against `memory-bank/use-cases/README.md`. | `STEP-01` | `none` | Source-specific detail appears necessary for acceptance. |
+| `STEP-03` | agent | `REQ-04` | Compare updated README guidance with `UC-XXX` template. | `memory-bank/use-cases/README.md`, `memory-bank/flows/templates/use-case/UC-XXX.md` | Compatibility note | `CHK-03` | `EVID-03` | Semantic review plus `python3 scripts/check_memory_bank_index.py` | `STEP-01` | `none` | Template conflict is found and cannot be resolved by README wording. |
+| `STEP-04` | agent | `CHK-03` | Run repository hygiene checks. | repository root | Check outputs | `CHK-03` | `EVID-03` | `python3 scripts/check_memory_bank_index.py`; `git diff --check` | `STEP-03` | `none` | Index audit or diff check fails for a reason outside FT-015 scope. |
+
+## Parallelizable Work
+
+- `PAR-01` `STEP-01` and `STEP-02` are sequential because the leakage check depends on final README wording.
+- `PAR-02` `STEP-03` and `STEP-04` can be run after `STEP-01`, but final acceptance needs both results.
+
+## Checkpoints
+
+| Checkpoint ID | Refs | Condition | Evidence IDs |
+| --- | --- | --- | --- |
+| `CP-01` | `STEP-01`, `CHK-01` | README contains operational/agentic guidance and UC-vs-SC routing. | `EVID-01` |
+| `CP-02` | `STEP-02`, `CHK-02` | README contains no source-specific terms from `NS-02`. | `EVID-02` |
+| `CP-03` | `STEP-03`, `STEP-04`, `CHK-03` | Template compatibility reviewed and local hygiene checks pass. | `EVID-03` |
+
+## Execution Risks
+
+| Risk ID | Risk | Impact | Mitigation | Trigger |
+| --- | --- | --- | --- | --- |
+| `ER-01` | Guidance becomes too broad and implies all operational checks deserve `UC-*`. | Violates `NEG-02` and weakens UC-vs-SC boundary. | Keep repetition, project-level ownership, and reusable pre/postcondition criteria explicit. | README text lacks a "keep in `SC-*` when local" rule. |
+| `ER-02` | Source examples leak downstream terms. | Violates `NS-02` and issue acceptance. | Run forbidden-term check and edit wording back to generic concepts. | `CHK-02` finds a match. |
+
+## Stop Conditions / Fallback
+
+| Stop ID | Related refs | Trigger | Immediate action | Safe fallback state |
+| --- | --- | --- | --- | --- |
+| `STOP-01` | `NS-02`, `NEG-01` | Acceptance appears to require source-specific source content. | Stop and create a human gate with facts and options. | Keep feature docs active; do not edit generic README further. |
+| `STOP-02` | `REQ-04`, `NS-03` | `UC-XXX` template conflict is found and cannot be fixed by README wording. | Stop and create a human gate before changing the template. | README guidance draft remains unmerged until owner decision. |
+
+## Plan-local Evidence
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checkpoints |
+| --- | --- | --- | --- | --- |
+| `EVID-09` | Review-improve report for feature documents | agent | `memory-bank/features/FT-015-pattern-operational-agentic-use-cases/feature-review-report.md` | `CP-01`, `CP-02`, `CP-03` |
+
+## Готово для приемки
+
+- Все workstreams завершены или явно остановлены через `STOP-*`.
+- Все checkpoints имеют evidence.
+- Required local commands from `Test Strategy` pass.
+- Manual-only gaps are limited to semantic template compatibility review and have a written verdict.
+- Final acceptance is evaluated against `brief.md` `Verify`, not this checklist.

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -24,6 +24,12 @@ audience: humans_and_agents
 - Если feature реализует или существенно меняет устойчивый сценарий проекта, она должна ссылаться на соответствующий `UC-*` из [`../use-cases/README.md`](../use-cases/README.md).
 - В шаблонном репозитории этот каталог может быть пустым. Это нормально.
 
+## Реестр
+
+| Feature ID | Title | Status | Delivery status | Source |
+| --- | --- | --- | --- | --- |
+| [`FT-015`](FT-015-pattern-operational-agentic-use-cases/README.md) | Operational and Agentic Use Cases Pattern | `active` | `in_progress` | [GitHub issue #15](https://github.com/dapi/memory-bank/issues/15) |
+
 ## Naming
 
 - Базовый формат: `FT-XXX/`

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -28,7 +28,7 @@ audience: humans_and_agents
 
 | Feature ID | Title | Status | Delivery status | Source |
 | --- | --- | --- | --- | --- |
-| [`FT-015`](FT-015-pattern-operational-agentic-use-cases/README.md) | Operational and Agentic Use Cases Pattern | `active` | `in_progress` | [GitHub issue #15](https://github.com/dapi/memory-bank/issues/15) |
+| [`FT-015`](FT-015-pattern-operational-agentic-use-cases/README.md) | Operational and Agentic Use Cases Pattern | `active` | `done` | [GitHub issue #15](https://github.com/dapi/memory-bank/issues/15) |
 
 ## Naming
 

--- a/memory-bank/use-cases/README.md
+++ b/memory-bank/use-cases/README.md
@@ -30,6 +30,35 @@ Use case нужен для сценария, который живет на ур
 - это implementation detail, а не продуктовый или операционный flow;
 - его достаточно описать через `SC-*` в `brief.md`.
 
+## Operational / Agentic Use Cases
+
+Operational и agentic use cases описывают устойчивые рабочие сценарии, где
+человек, автоматизированный агент, сервис или команда выполняет повторяемую
+операционную работу: передает контекст, восстанавливается после сбоя,
+координирует параллельную доставку, проверяет готовность окружения или
+публикует статус для следующего участника flow.
+
+Такой сценарий может стать `UC-*`, если он:
+
+- повторяется во времени и не принадлежит только одной delivery-единице;
+- имеет стабильный trigger, preconditions, main flow, exceptions и
+  postconditions;
+- должен быть upstream для нескольких features, runbooks, prompts или ops docs;
+- задает machine-readable contract, status или handoff format, который другие
+  участники flow должны читать одинаково;
+- описывает recovery/postconditions, которые важны независимо от конкретной
+  реализации feature.
+
+Оставляй сценарий в feature-level `SC-*`, если он нужен только для приемки
+одной delivery-единицы, проверяет локальный edge case или описывает
+implementation detail без самостоятельного project-level behavior.
+
+Machine-readable status, structured diagnostics, handoff payloads, recovery
+outcomes и postconditions допустимо описывать в `UC-*`, когда они являются
+наблюдаемым контрактом сценария. При этом use case фиксирует поведение и
+границы сценария, а не implementation sequence, архитектуру или
+feature-level test matrix.
+
 ## Реестр
 
 | UC ID | Title | Status | Primary actor | Upstream PRD | Implemented by | Last updated |


### PR DESCRIPTION
## Summary

- Adds generic operational/agentic use case guidance to `memory-bank/use-cases/README.md`.
- Clarifies when an ops/agentic scenario belongs in project-level `UC-*` versus feature-level `SC-*`.
- Documents FT-015 feature package, decisions, implementation plan, review report, and verification evidence.

Fixes #15

## Validation

- `rg --files memory-bank`
- `rg -n "Operational|agentic|machine-readable|recovery|postconditions|SC-\*" memory-bank/use-cases/README.md`
- `rg -n "zelma|zellij|Codex|sessions list|setup --json" memory-bank/use-cases/README.md` returned no matches as expected
- `python3 scripts/check_memory_bank_index.py`
- `git diff --check`

## Notes

- `UC-XXX` template was reviewed and left unchanged because its existing trigger/preconditions/main flow/exceptions/postconditions structure is compatible with the new guidance.
