### PR TITLE
[codex] add optional ui design guide pattern

### DIFF
--- a/memory-bank/engineering/README.md
+++ b/memory-bank/engineering/README.md
@@ -15,6 +15,7 @@ audience: humans_and_agents
 
 - [Engineering Architecture Patterns](architecture.md) — code/module boundaries, runtime patterns, concurrency, error handling и configuration ownership. Domain bounded contexts живут отдельно в [`../domain/context-map.md`](../domain/context-map.md).
 - [Frontend Engineering](frontend.md) — UI surfaces, frontend stack, component boundaries, design system integration и i18n.
+- [UI Design Guide](ui-design-guide/README.md) — optional companion для проектов с существующим UI kit: components, forms, actions, tables, navigation, states, screenshots, source paths и agent instructions.
 - [Testing Policy](testing-policy.md) — правила тестирования, обязательные automated tests, sufficient coverage. Отвечает на вопрос: когда feature обязана иметь test cases и когда допустим manual-only verify.
 - [Autonomy Boundaries](autonomy-boundaries.md) — границы автономии агента: автопилот, супервизия, эскалация. Отвечает на вопрос: что агент может делать сам, а где должен остановиться и спросить.
 - [Coding Style](coding-style.md) — конвенции оформления кода, tooling и правила локальной сложности.

--- a/memory-bank/engineering/frontend.md
+++ b/memory-bank/engineering/frontend.md
@@ -16,6 +16,8 @@ audience: humans_and_agents
 
 Product-level experience principles живут в [`../product/vision.md`](../product/vision.md). Domain language и rules живут в [`../domain/`](../domain/README.md). Здесь фиксируй engineering contract для UI.
 
+Если downstream-проект уже имеет устойчивый UI kit, admin/operator views, screenshots или helper APIs, можно добавить optional companion [`ui-design-guide/README.md`](ui-design-guide/README.md). Этот companion фиксирует concrete local UI reference material для агентов, но не заменяет frontend engineering contract в этом документе.
+
 ## UI Surfaces
 
 Опиши основные интерфейсы системы.

--- a/memory-bank/engineering/ui-design-guide/README.md
+++ b/memory-bank/engineering/ui-design-guide/README.md
@@ -1,0 +1,105 @@
+---
+title: UI Design Guide
+doc_kind: engineering
+doc_function: index
+purpose: Optional template for documenting an existing project UI kit: components, forms, actions, tables, navigation, states, screenshots, source paths and agent instructions.
+derived_from:
+  - ../../dna/governance.md
+  - ../frontend.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - product_requirements
+  - domain_rules
+  - frontend_architecture_contract
+  - implementation_sequence
+---
+
+# UI Design Guide
+
+This optional guide helps downstream projects document an existing UI kit or admin/operator interface patterns. Use it when agents need a fast source of truth for concrete components, helper APIs, screenshots, local interaction conventions and source code paths.
+
+If the project has no reusable UI kit or separate frontend/admin UI, leave this section minimal or remove it during adaptation. The canonical frontend engineering contract stays in [`../frontend.md`](../frontend.md); this guide records concrete local UI reference material.
+
+## Owner Boundaries
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| `../frontend.md` | UI surfaces, frontend stack, component boundaries, design system integration and i18n contract | Detailed component catalog, screenshots and local examples |
+| `ui-design-guide/README.md` | Existing UI kit reference, local component usage, helper APIs, screenshots and agent-facing UI instructions | Product requirements, domain rules, architecture decisions or implementation sequencing |
+| `../architecture.md` / ADR | Architecture and reusable engineering decisions | Component screenshots or per-screen local conventions |
+
+## How To Adapt
+
+Replace placeholder rows with project-specific facts after copying the template into a downstream repository.
+
+- Prefer links to canonical source files over prose descriptions.
+- Keep screenshots versioned or linkable when they are required for agent review.
+- Document current local patterns before inventing new ones.
+- If a UI rule is product-specific, link to the product or feature owner instead of redefining it here.
+- If a UI rule changes frontend architecture, update [`../frontend.md`](../frontend.md) or an ADR first.
+
+## UI Surfaces
+
+| Surface ID | Surface | Users / roles | Source paths | Notes |
+| --- | --- | --- | --- | --- |
+| `UI-SURF-01` | Example: admin dashboard | Example: operators | `path/to/ui` | Replace with local surface facts |
+
+## Components
+
+| Component ID | Component / pattern | When to use | Source paths | Examples / screenshots |
+| --- | --- | --- | --- | --- |
+| `UI-CMP-01` | Example: reusable panel, modal, badge or field wrapper | Describe the local usage rule | `path/to/component` | `path/to/screenshot-or-example` |
+
+## Forms
+
+| Form pattern ID | Pattern | Validation / errors | Helper APIs | Source paths |
+| --- | --- | --- | --- | --- |
+| `UI-FORM-01` | Example: create/edit form | Describe how required, invalid and async states are shown | `helper_or_component_name` | `path/to/form` |
+
+## Buttons And Actions
+
+| Action ID | Action type | Visual / placement rule | State rule | Source paths |
+| --- | --- | --- | --- | --- |
+| `UI-ACT-01` | Example: primary action, destructive action, bulk action | Describe local placement and priority | Describe disabled/loading/confirmation behavior | `path/to/action` |
+
+## Tables
+
+| Table ID | Table pattern | Sorting / filtering / pagination | Empty / loading / error states | Source paths |
+| --- | --- | --- | --- | --- |
+| `UI-TBL-01` | Example: index table | Describe local data controls | Describe state rendering | `path/to/table` |
+
+## Navigation
+
+| Navigation ID | Pattern | Applies to | Source paths | Notes |
+| --- | --- | --- | --- | --- |
+| `UI-NAV-01` | Example: sidebar, tabs, breadcrumbs or contextual links | Describe surfaces or roles | `path/to/navigation` | Replace with local routing conventions |
+
+## States And Labels
+
+Document canonical UI labels and state rendering only when they are stable local conventions. Link to domain or product owners for business meaning.
+
+| State / label ID | UI state or label | Meaning in UI | Owner / source | Examples |
+| --- | --- | --- | --- | --- |
+| `UI-LBL-01` | Example: visible status label | Describe display semantics | `path/to/source` | `path/to/example` |
+
+## Screenshots And Examples
+
+| Screenshot ID | What it shows | Surface / component refs | Path or link | Refresh rule |
+| --- | --- | --- | --- | --- |
+| `UI-SHOT-01` | Example: filled form state | `UI-FORM-01` | `path/to/screenshot` | Update when local UI pattern changes |
+
+## Source Code Paths
+
+| Path ID | Path | Contains | Use when | Notes |
+| --- | --- | --- | --- | --- |
+| `UI-PATH-01` | `path/to/ui` | Local UI components, helpers or views | Agent needs concrete examples before changing UI | Replace with project paths |
+
+## Agent Instructions
+
+- Start with [`../frontend.md`](../frontend.md) to understand stack and ownership boundaries.
+- Then inspect the relevant source paths in this guide before changing UI.
+- Reuse existing local components, helpers and state patterns before adding new ones.
+- Do not infer business meaning from visual labels; follow linked domain/product owners.
+- Do not treat placeholder examples in this guide as framework defaults.
+- If local examples conflict with canonical requirements, update the owner document before changing implementation.

--- a/memory-bank/features/FT-017/README.md
+++ b/memory-bank/features/FT-017/README.md
@@ -1,0 +1,34 @@
+---
+title: "FT-017: Feature Package"
+doc_kind: feature
+doc_function: index
+purpose: "Навигация по feature package для optional UI design guide pattern. Читать, чтобы перейти к canonical brief, solution decision log, design и execution plan."
+derived_from:
+  - ../../dna/governance.md
+  - brief.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-017: Feature Package
+
+## О разделе
+
+Этот package ведет issue 17: добавить generic optional UI design guide pattern для frontend/admin UI без переноса downstream-specific framework assumptions в шаблонный memory-bank.
+
+## Аннотированный индекс
+
+- [`brief.md`](brief.md)
+  Читать, когда нужно: проверить problem space, scope/non-scope, Design Requirement Decision и canonical verify contract для FT-017.
+
+- [`decision-log.md`](decision-log.md)
+  Читать, когда нужно: увидеть feature-local решения, закрытые через FPF, и факты, на которых они основаны.
+
+- [`design.md`](design.md)
+  Читать, когда нужно: проверить selected solution, alternatives, C4 applicability, contracts и local failure modes для реализации optional UI design guide pattern.
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Читать, когда нужно: исполнить feature через grounded workstreams, checkpoints и verification commands без переопределения `brief.md` или `design.md`.
+
+- [`feature-review-report.md`](feature-review-report.md)
+  Читать, когда нужно: увидеть результат review-improve циклов по комплекту feature-документов.

--- a/memory-bank/features/FT-017/brief.md
+++ b/memory-bank/features/FT-017/brief.md
@@ -1,0 +1,120 @@
+---
+title: "FT-017: Optional UI Design Guide Pattern"
+doc_kind: feature
+doc_function: canonical
+purpose: "Canonical brief для delivery-единицы issue 17. Фиксирует problem space, scope и verify contract для optional UI design guide pattern без смешения с solution space или execution plan."
+derived_from:
+  - ../../flows/feature-flow.md
+  - ../../engineering/frontend.md
+status: active
+delivery_status: done
+audience: humans_and_agents
+source_issue:
+  id: 17
+  url: "https://github.com/dapi/memory-bank/issues/17"
+must_not_define:
+  - implementation_sequence
+  - solution_space
+---
+
+# FT-017: Optional UI Design Guide Pattern
+
+## What
+
+### Problem
+
+В проектах с существующим UI агентам нужен быстрый источник истины по компонентам, helper APIs, screenshots и локальным UI-паттернам. Сейчас generic memory-bank содержит [`engineering/frontend.md`](../../engineering/frontend.md) как engineering contract для UI surfaces, frontend stack, component boundaries, design system integration и i18n, но не дает отдельного optional destination/template для документирования уже существующего UI kit.
+
+Issue 17 приводит downstream source examples из `brandymint/merchantly`, но требует не переносить framework-specific правила в generic memory-bank.
+
+### Outcome
+
+| Metric ID | Metric | Baseline | Target | Measurement method |
+| --- | --- | --- | --- | --- |
+| `MET-01` | Discoverability of optional UI guide pattern | Downstream project can read `frontend.md`, but no dedicated optional UI kit guide destination exists | README/index files and `frontend.md` route readers to an optional UI design guide pattern | `CHK-01`, `CHK-02` |
+| `MET-02` | Generic template safety | Source examples are project-specific and may include local framework assumptions | Added docs are framework-agnostic and do not prescribe project-specific UI defaults | `CHK-02`, `CHK-03` |
+
+### Scope
+
+- `REQ-01` Add a generic optional destination/template for documenting an existing UI design guide / UI kit.
+- `REQ-02` The destination/template must recommend sections for components, forms, buttons/actions, tables, navigation, states/labels, screenshots, source code paths and agent instructions.
+- `REQ-03` Link the optional UI design guide pattern from [`../../engineering/frontend.md`](../../engineering/frontend.md) and relevant README/index files without making it mandatory for projects that do not have a separate UI layer.
+- `REQ-04` Keep generic memory-bank free from project-specific framework assumptions, including source-project UI framework defaults.
+
+### Non-Scope
+
+- `NS-01` Do not copy downstream project UI rules, screenshots, helper APIs or code paths into the generic template.
+- `NS-02` Do not prescribe Bootstrap, Inspinia, HAML or any other source-project stack as generic defaults.
+- `NS-03` Do not change runtime UI implementation, design tokens, components or product UX.
+- `NS-04` Do not create or update downstream project instances; this feature only changes the portable memory-bank template.
+
+### Constraints / Assumptions
+
+- `ASM-01` Issue 17 source paths are treated as evidence that this documentation pattern is useful, not as reusable generic content.
+- `ASM-02` [`../../engineering/frontend.md`](../../engineering/frontend.md) remains the canonical owner for frontend engineering contract.
+- `CON-01` Generic memory-bank must remain portable and framework-agnostic.
+- `CON-02` Domain docs must not become the owner of UI design system content; [`../../domain/README.md`](../../domain/README.md) explicitly excludes UI design system from domain ownership.
+
+## Design Requirement Decision
+
+| Decision | Reason | Downstream owner |
+| --- | --- | --- |
+| `Design required: yes` | The feature requires choosing the owner/location of a new optional documentation pattern and resolving the trade-off between expanding `frontend.md`, adding an optional destination, or adding a template route. | `design.md` |
+
+## Verify
+
+`Verify` задает canonical test case inventory для delivery-единицы. Execution details live in [`implementation-plan.md`](implementation-plan.md).
+
+### Exit Criteria
+
+- `EC-01` A generic optional UI design guide destination/template exists and includes the section set required by `REQ-02`.
+- `EC-02` [`../../engineering/frontend.md`](../../engineering/frontend.md) and relevant README/index files route to the optional guide and explicitly present it as optional.
+- `EC-03` Added generic docs do not contain project-specific framework defaults or copied downstream project content.
+
+### Traceability matrix
+
+| Requirement ID | Problem refs | Acceptance refs | Checks | Evidence IDs |
+| --- | --- | --- | --- | --- |
+| `REQ-01` | `ASM-01`, `ASM-02`, `CON-01` | `EC-01`, `SC-01` | `CHK-01`, `CHK-03` | `EVID-01`, `EVID-03` |
+| `REQ-02` | `ASM-01`, `CON-01` | `EC-01`, `SC-01` | `CHK-02`, `CHK-03` | `EVID-02`, `EVID-03` |
+| `REQ-03` | `ASM-02` | `EC-02`, `SC-02` | `CHK-01`, `CHK-03` | `EVID-01`, `EVID-03` |
+| `REQ-04` | `ASM-01`, `CON-01`, `CON-02` | `EC-03`, `NEG-01` | `CHK-02`, `CHK-03` | `EVID-02`, `EVID-03` |
+
+### Acceptance Scenarios
+
+- `SC-01` A downstream project with an existing admin/operator UI can find and instantiate an optional UI design guide that asks for components, forms, actions, tables, navigation, states/labels, screenshots, source paths and agent instructions.
+- `SC-02` An agent reading frontend engineering guidance can discover the optional UI design guide as a companion reference, while `frontend.md` remains the canonical engineering contract.
+
+### Negative / Edge Scenarios
+
+- `NEG-01` If source-project examples contain stack-specific UI rules, the generic template does not promote those rules to defaults and instead asks downstream projects to document their own local stack.
+
+### Checks
+
+| Check ID | Covers | How to check | Expected result | Evidence path |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `EC-01`, `EC-02`, `SC-01`, `SC-02` | Run `python3 scripts/check_memory_bank_index.py` and `rg --files memory-bank` after implementation. | Navigation links are valid; the optional guide path is discoverable from relevant indexes. | `memory-bank/features/FT-017/evidence/chk-01/` |
+| `CHK-02` | `EC-01`, `EC-03`, `NEG-01` | Review added docs and run targeted `rg` checks against the new optional guide and touched routing docs. | Required sections exist; target generic docs do not prescribe source-project frameworks or copied downstream content. | `memory-bank/features/FT-017/evidence/chk-02/` |
+| `CHK-03` | `EC-01`, `EC-02`, `EC-03`, `SC-01`, `SC-02`, `NEG-01` | Run `git diff --check` and manually inspect touched docs for owner-boundary consistency. | No whitespace/conflict markers; `frontend.md`, indexes and optional guide do not contradict `brief.md`/`design.md`. | `memory-bank/features/FT-017/evidence/chk-03/` |
+
+### Test matrix
+
+| Check ID | Evidence IDs | Evidence path |
+| --- | --- | --- |
+| `CHK-01` | `EVID-01` | `memory-bank/features/FT-017/evidence/chk-01/` |
+| `CHK-02` | `EVID-02` | `memory-bank/features/FT-017/evidence/chk-02/` |
+| `CHK-03` | `EVID-03` | `memory-bank/features/FT-017/evidence/chk-03/` |
+
+### Evidence
+
+- `EVID-01` Link/index audit output showing the optional guide is reachable and markdown dependencies are valid.
+- `EVID-02` Content guard output or review note proving generic docs avoid source-project framework defaults and include required guide sections.
+- `EVID-03` Final diff hygiene and owner-boundary review note.
+
+### Evidence contract
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checks |
+| --- | --- | --- | --- | --- |
+| `EVID-01` | Link/index audit log | implementer | `memory-bank/features/FT-017/evidence/chk-01/result.txt` | `CHK-01` |
+| `EVID-02` | Content guard log or review note | implementer / reviewer | `memory-bank/features/FT-017/evidence/chk-02/result.txt` | `CHK-02` |
+| `EVID-03` | Diff hygiene and owner-boundary review note | implementer / reviewer | `memory-bank/features/FT-017/evidence/chk-03/result.txt` | `CHK-03` |

--- a/memory-bank/features/FT-017/decision-log.md
+++ b/memory-bank/features/FT-017/decision-log.md
@@ -1,0 +1,36 @@
+---
+title: "FT-017: Decision Log"
+doc_kind: feature
+doc_function: log
+purpose: "Feature-local decision log for issue 17. Records FPF-backed decisions that close open questions for the optional UI design guide pattern without requiring a global ADR."
+derived_from:
+  - brief.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-017: Decision Log
+
+## Decision Criteria
+
+The following feature-local criteria are derived from issue 17 and the current memory-bank documents:
+
+- `DC-01` The solution must help downstream projects document an existing UI kit.
+- `DC-02` The generic template must stay portable and framework-agnostic.
+- `DC-03` The owner boundary with [`../../engineering/frontend.md`](../../engineering/frontend.md) must stay clear.
+- `DC-04` Domain-specific and project-specific UI content must not leak back into the generic template.
+
+FPF application:
+
+- Bounded Context: local source-project rules must stay inside the downstream project context; generic memory-bank may only publish reusable structure and translation prompts.
+- Strict Distinction: `frontend.md` remains an engineering contract, while the optional UI design guide is a reference carrier for concrete UI kit facts in a downstream instance.
+- Reasoning Cycle: abductive candidates were compared against documented constraints, then selected only when their consequences satisfied `DC-*`.
+
+## Decisions
+
+| Decision ID | Status | Question | Decision | Facts used | FPF rationale | Consequences |
+| --- | --- | --- | --- | --- | --- | --- |
+| `FDL-001` | accepted | Where should the optional UI design guide live? | Use `memory-bank/engineering/ui-design-guide/README.md` as the optional engineering-layer destination/template, not a domain-layer owner. | Issue 17 asks to link with `engineering/frontend.md`; `frontend.md` owns UI surfaces, frontend stack, component boundaries and design system integration; `domain/README.md` explicitly excludes UI design system ownership. | Bounded Context keeps UI engineering facts in the engineering semantic frame. Strict Distinction prevents treating UI design system guidance as domain truth. | `design.md` selects an engineering optional destination and rejects `domain/design-guide` as the generic owner. |
+| `FDL-002` | accepted | Should the feature only expand `frontend.md` or add a separate optional guide pattern? | Add a separate optional guide pattern and link to it from `frontend.md` / indexes. | Issue 17 asks for a quick source of truth over components, helper APIs, screenshots and local patterns; `frontend.md` currently describes broader frontend engineering contracts. | Strict Distinction separates the engineering contract from concrete UI kit reference material. The reasoning cycle predicts that putting all UI kit details into `frontend.md` would blur owner roles. | `frontend.md` remains canonical for frontend engineering; the optional guide carries detailed UI kit sections. |
+| `FDL-003` | accepted | Does this feature need C4 or ADR? | C4 artifact and ADR are not required. | The feature is documentation-template work; no API, runtime, deployment, data-flow, integration, security or reusable architecture boundary changes are in scope. | Feature-flow C4 triggers are absent. Strict Distinction keeps documentation structure decisions feature-local unless they alter architecture across features. | `design.md` records `C4-00: not required` and keeps decisions in this log / `design.md` rather than ADR. |
+| `FDL-004` | accepted | Can source-project examples be treated as generic defaults? | No. They are evidence of need only; they are not reusable generic content. | Issue 17 names `brandymint/merchantly` source files and explicitly says not to transfer Bootstrap/Inspinia/HAML-specific rules as generic defaults. | Evidence Graph discipline separates a source carrier from the claim it supports. The source paths support the existence of the documentation need, not the portability of their local rules. | `brief.md` uses `ASM-01`, `NS-01`, `NS-02` and `REQ-04`; implementation must use placeholders and prompts, not copied downstream facts. |

--- a/memory-bank/features/FT-017/design.md
+++ b/memory-bank/features/FT-017/design.md
@@ -1,0 +1,109 @@
+---
+title: "FT-017: Design"
+doc_kind: feature
+doc_function: canonical
+purpose: "Solution-space документ для FT-017. Фиксирует selected approach, rationale, C4 applicability, contracts and failure modes for optional UI design guide pattern without redefining scope or execution sequencing."
+derived_from:
+  - brief.md
+  - decision-log.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_017_scope
+  - ft_017_acceptance_criteria
+  - ft_017_evidence_contract
+  - implementation_sequence
+---
+
+# FT-017: Design
+
+## Design Pack
+
+| Artifact | Role | Owns |
+| --- | --- | --- |
+| `design.md` | Feature-local solution owner | `SOL-*`, `ALT-*`, `TRD-*`, `C4-*`, `SD-*`, feature-local `CTR-*`, `INV-*`, `FM-*`, `RB-*` |
+| `decision-log.md` | Feature-local decision provenance | FPF-backed `FDL-*` decisions and facts used to close open questions |
+
+## Context
+
+FT-017 adds a generic optional documentation pattern. The design problem is ownership: issue 17 asks for a practical source of truth for existing UI components and local UI conventions, but generic memory-bank must not import downstream framework assumptions.
+
+Existing documents set the owner boundaries:
+
+- [`../../engineering/frontend.md`](../../engineering/frontend.md) owns frontend engineering contracts such as UI surfaces, component boundaries, design system integration and i18n.
+- [`../../domain/README.md`](../../domain/README.md) states that domain docs do not define UI design system content.
+- [`brief.md`](brief.md) requires discoverability, optionality and framework-agnostic content.
+
+## C4 Applicability
+
+| C4 ID | Decision | Trigger / reason | Artifact |
+| --- | --- | --- | --- |
+| `C4-00` | `not required` | The feature changes documentation structure and template guidance only. It does not change runtime, container, API, event, schema, file format, security, integration or component collaboration boundaries. | `none` |
+
+## Selected Solution
+
+- `SOL-01` Add `memory-bank/engineering/ui-design-guide/README.md` as an optional engineering-layer UI design guide destination/template for downstream projects with existing UI kits. It should ask for components, forms, buttons/actions, tables, navigation, states/labels, screenshots, source code paths and agent instructions, satisfying `REQ-01` and `REQ-02`.
+- `SOL-02` Link the optional guide from `memory-bank/engineering/frontend.md` and `memory-bank/engineering/README.md` while labeling it optional, satisfying `REQ-03`.
+- `SOL-03` Keep all guide content generic: use placeholders, prompts and guardrails instead of copied source-project framework rules, satisfying `REQ-04`.
+
+## Alternatives Considered
+
+| Alternative ID | Option | Why not selected |
+| --- | --- | --- |
+| `ALT-01` | Put the generic guide under `memory-bank/domain/design-guide/` because the source project used that path. | Rejected by `FDL-001`: current `domain/README.md` explicitly excludes UI design system ownership, and issue 17 asks to connect the pattern with engineering frontend guidance. |
+| `ALT-02` | Only expand `engineering/frontend.md` with all UI kit guide sections. | Rejected by `FDL-002`: `frontend.md` should stay a concise engineering contract; concrete UI kit reference material needs a separate optional companion to avoid owner blurring. |
+| `ALT-03` | Add only a flow template route without an instantiated optional destination in the memory-bank adaptation layer. | Not selected for this feature because issue 17 acceptance requires README/index discoverability of the optional layer. A destination/template in the engineering layer is more directly discoverable for downstream adaptation. |
+
+## Trade-offs
+
+| Trade-off ID | Decision | Benefit | Cost / Risk |
+| --- | --- | --- | --- |
+| `TRD-01` | Add a separate optional guide instead of embedding everything in `frontend.md`. | Better source-of-truth ergonomics for UI-heavy projects and clearer owner boundary. | One more optional document must be indexed and clearly labeled as optional. |
+| `TRD-02` | Use generic prompts/placeholders instead of source-project examples. | Keeps memory-bank portable and avoids accidental framework defaults. | The template is less concrete than a copied project-specific guide; downstream projects must fill local details. |
+
+## Accepted Local Decisions
+
+- `SD-01` The selected owner is the engineering documentation layer, with `frontend.md` as the route to the optional companion.
+- `SD-02` The source-project paths in issue 17 are evidence of need, not content sources for the generic guide.
+- `SD-03` No ADR is required because the decision is feature-local documentation structure and does not alter reusable architecture.
+
+## Contracts
+
+| Contract ID | Input / Output | Producer / Consumer | Semantics / Constraints |
+| --- | --- | --- | --- |
+| `CTR-01` | `memory-bank/engineering/ui-design-guide/README.md` | Generic memory-bank template producer / downstream project adapter | The document must define structure and prompts only; downstream projects own actual components, screenshots, helper APIs and local rules. |
+| `CTR-02` | `memory-bank/engineering/frontend.md` and `memory-bank/engineering/README.md` links | Generic memory-bank template producer / reader agent | Links must present the guide as optional and route from frontend engineering context. |
+| `CTR-03` | Framework-specific source facts | Issue 17 source references / generic template | Source-project framework choices must not become generic defaults. |
+
+## Invariants
+
+- `INV-01` `frontend.md` remains the canonical frontend engineering contract.
+- `INV-02` Domain docs do not become owners of UI design system or UI kit content.
+- `INV-03` The optional guide must be usable by projects with different UI stacks.
+
+## Failure Modes
+
+- `FM-01` Project-specific rules leak into generic docs. Mitigation: use placeholders, avoid framework defaults in target generic docs, and verify with `CHK-02`.
+- `FM-02` The optional guide is perceived as mandatory for all projects. Mitigation: label it optional in routing docs and keep `frontend.md` valid without it.
+- `FM-03` `frontend.md` and the optional guide duplicate ownership. Mitigation: `frontend.md` routes to the guide for concrete UI kit details, while the guide points back to frontend engineering as the contract owner.
+
+## Rollout / Backout
+
+| Stage ID | Stage | Entry condition | Backout |
+| --- | --- | --- | --- |
+| `RB-01` | Add optional guide and routing links | `brief.md`, `decision-log.md` and `design.md` are active | Remove the new optional guide and routing links; `frontend.md` remains the fallback frontend engineering contract. |
+
+## ADR / External Design Dependencies
+
+| Artifact | Current status | Used for | Rule |
+| --- | --- | --- | --- |
+| `none` | not applicable | No architectural or reusable cross-feature decision is required. | Keep decisions feature-local unless implementation discovers an architecture-level owner change. |
+
+## Traceability
+
+| Requirement ID | Solution refs | Contracts / invariants | Failure / rollout refs |
+| --- | --- | --- | --- |
+| `REQ-01` | `SOL-01`, `TRD-01`, `SD-01` | `CTR-01`, `INV-01`, `INV-03` | `FM-02`, `FM-03`, `RB-01` |
+| `REQ-02` | `SOL-01`, `TRD-02`, `SD-02` | `CTR-01`, `CTR-03`, `INV-03` | `FM-01`, `RB-01` |
+| `REQ-03` | `SOL-02`, `TRD-01`, `SD-01` | `CTR-02`, `INV-01` | `FM-02`, `FM-03`, `RB-01` |
+| `REQ-04` | `SOL-03`, `TRD-02`, `SD-02`, `SD-03` | `CTR-01`, `CTR-03`, `INV-02`, `INV-03` | `FM-01`, `RB-01` |

--- a/memory-bank/features/FT-017/evidence/chk-01/result.txt
+++ b/memory-bank/features/FT-017/evidence/chk-01/result.txt
@@ -1,0 +1,14 @@
+CHK-01 result: pass
+
+Commands:
+- python3 scripts/check_memory_bank_index.py
+- rg --files memory-bank | sort
+
+Observed:
+- Memory-bank link audit result: OK.
+- No broken internal markdown links.
+- No broken frontmatter markdown dependencies.
+- No orphan markdown files.
+- All scoped markdown files are reachable from memory-bank/README.md via index navigation.
+- Index compliance: OK.
+- memory-bank/engineering/ui-design-guide/README.md appears in rg --files output and is reachable through memory-bank/engineering/README.md.

--- a/memory-bank/features/FT-017/evidence/chk-02/result.txt
+++ b/memory-bank/features/FT-017/evidence/chk-02/result.txt
@@ -1,0 +1,11 @@
+CHK-02 result: pass
+
+Commands:
+- rg -n "components|forms|buttons|actions|tables|navigation|states|labels|screenshots|source code paths|agent instructions" memory-bank/engineering/ui-design-guide/README.md memory-bank/engineering/frontend.md memory-bank/engineering/README.md
+- rg -n "brandymint|merchantly|Inspinia|HAML" memory-bank --glob '!memory-bank/features/FT-017/**'
+
+Observed:
+- memory-bank/engineering/ui-design-guide/README.md includes sections for components, forms, buttons/actions, tables, navigation, states/labels, screenshots, source code paths and agent instructions.
+- The guide includes helper APIs and source path prompts.
+- Source-specific downstream terms were not found outside the FT-017 feature package.
+- Manual semantic review: the new guide uses placeholders and local-adaptation prompts, not copied downstream project rules or framework defaults.

--- a/memory-bank/features/FT-017/evidence/chk-03/result.txt
+++ b/memory-bank/features/FT-017/evidence/chk-03/result.txt
@@ -1,0 +1,14 @@
+CHK-03 result: pass
+
+Commands:
+- git diff --check
+- sed -n '1,160p' memory-bank/engineering/ui-design-guide/README.md
+- sed -n '1,120p' memory-bank/engineering/frontend.md
+- sed -n '1,120p' memory-bank/engineering/README.md
+
+Observed:
+- git diff --check produced no whitespace or conflict marker findings.
+- memory-bank/engineering/ui-design-guide/README.md has YAML frontmatter with status: active and doc_function: index.
+- memory-bank/engineering/frontend.md links the guide as an optional companion and keeps frontend engineering contract ownership.
+- memory-bank/engineering/README.md contains an annotated link to the optional UI Design Guide.
+- Manual owner-boundary review: the guide does not redefine product requirements, domain rules, frontend architecture contract or implementation sequence.

--- a/memory-bank/features/FT-017/feature-review-report.md
+++ b/memory-bank/features/FT-017/feature-review-report.md
@@ -1,0 +1,113 @@
+---
+title: "FT-017: Feature Review Report"
+doc_kind: feature
+doc_function: report
+purpose: "Финальный отчет review-improve циклов для комплекта feature-документов FT-017."
+derived_from:
+  - brief.md
+  - decision-log.md
+  - design.md
+  - implementation-plan.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-017: Feature Review Report
+
+## Cycle 1
+
+### Краткий итог ревью
+
+Feature package для issue 17 отсутствовал: в `memory-bank/features/` был только общий README. Это блокировало ведение feature-flow, traceability issue 17 и дальнейший review-improve по комплекту feature-документов.
+
+### Critical / Important
+
+| Priority | Finding | Resolution |
+| --- | --- | --- |
+| `critical` | Нет `memory-bank/features/FT-017/README.md` и `brief.md`, поэтому feature не имеет canonical problem owner. | Созданы `README.md` и active `brief.md` по feature-flow. |
+| `critical` | Нет feature-local decision log, хотя owner/location decisions materially влияют на feature и пользователь потребовал фиксировать FPF decisions в decision log. | Создан `decision-log.md` с `FDL-001` through `FDL-004`. |
+| `important` | Не закрыты решения: destination/template owner, связь с `frontend.md`, допустимость source-project content, необходимость C4/ADR. | Решения закрыты через FPF и перенесены в `decision-log.md` / `design.md`. |
+| `important` | Нет solution owner и execution plan, поэтому невозможно проверить расхождения между brief, design, implementation plan и verify/evidence. | Созданы active `design.md` и active `implementation-plan.md`. |
+
+### Open questions closed through FPF
+
+- `FDL-001`: optional UI design guide belongs to `memory-bank/engineering/ui-design-guide/README.md`, not a domain-layer owner.
+- `FDL-002`: add a separate optional guide pattern instead of expanding only `frontend.md`.
+- `FDL-003`: C4 artifact and ADR are not required for this documentation-template feature.
+- `FDL-004`: source-project examples are evidence of need, not reusable generic defaults.
+
+### Changes made
+
+- Created `README.md`, `brief.md`, `decision-log.md`, `design.md`, `implementation-plan.md` and this report under `memory-bank/features/FT-017/`.
+
+### Human gate
+
+No human gate.
+
+## Cycle 2
+
+### Краткий итог ревью
+
+Комплект feature-документов был создан, а repository checks прошли, но review выявил два important defects в owner graph и execution specificity.
+
+### Critical / Important
+
+| Priority | Finding | Resolution |
+| --- | --- | --- |
+| `important` | `decision-log.md` and `design.md` referenced each other through `derived_from`, creating an unnecessary circular dependency between decision provenance and solution owner. | Removed `design.md` from `decision-log.md` `derived_from`; `design.md` remains derived from `decision-log.md`. |
+| `important` | `SOL-01` and `STEP-01` left the target destination as an "engineering-layer destination/template" / "or equivalent path", making implementation-plan sequencing choose a solution fact. | Fixed selected path as `memory-bank/engineering/ui-design-guide/README.md` in `FDL-001`, `SOL-01`, `CTR-01` and `STEP-01`. |
+
+### Open questions closed through FPF
+
+None in this cycle; the path specificity follows `FDL-001` and `SD-01`.
+
+### Changes made
+
+Updated `decision-log.md`, `design.md`, `implementation-plan.md` and this report.
+
+### Human gate
+
+No human gate.
+
+## Cycle 3
+
+### Краткий итог ревью
+
+Комплект feature-документов стал целостным: `brief.md` owns problem/verify, `decision-log.md` records FPF decisions without circular dependency, `design.md` owns exact solution facts, and `implementation-plan.md` owns execution sequencing against the selected path. Repository link/frontmatter/index checks and diff hygiene pass.
+
+### Critical / Important
+
+None.
+
+### Open questions closed through FPF
+
+None in this cycle.
+
+### Changes made
+
+None in this cycle.
+
+### Human gate
+
+No human gate.
+
+## Final Status
+
+| Field | Value |
+| --- | --- |
+| Status | `done` |
+| Cycles executed | `3` |
+| Decision log | `memory-bank/features/FT-017/decision-log.md` |
+
+## Closed Critical / Important Findings
+
+- Missing feature package and canonical `brief.md`.
+- Missing feature-local decision log for FPF decisions.
+- Missing solution owner for owner/location decisions.
+- Missing execution plan and traceability between feature docs.
+- Circular `derived_from` between decision log and design.
+- Ambiguous selected destination path between design and implementation plan.
+
+## Remaining Findings
+
+No remaining `critical` or `important` findings.

--- a/memory-bank/features/FT-017/implementation-plan.md
+++ b/memory-bank/features/FT-017/implementation-plan.md
@@ -1,0 +1,148 @@
+---
+title: "FT-017: Implementation Plan"
+doc_kind: feature
+doc_function: derived
+purpose: "Execution plan for FT-017. Fixes grounded workstreams, steps, risks and test strategy without redefining problem or solution facts."
+derived_from:
+  - brief.md
+  - design.md
+  - decision-log.md
+status: archived
+audience: humans_and_agents
+must_not_define:
+  - ft_017_scope
+  - ft_017_selected_design
+  - ft_017_acceptance_criteria
+  - ft_017_blocker_state
+---
+
+# FT-017: Implementation Plan
+
+## Цель текущего плана
+
+Implement the optional UI design guide pattern selected in [`design.md`](design.md): add the generic guide destination/template, route to it from frontend/index docs, and verify that the result is discoverable, optional and framework-agnostic.
+
+## Grounding / Support References
+
+| Document | Role in this plan | Facts reused | Conflict action |
+| --- | --- | --- | --- |
+| `brief.md` | canonical problem / verify owner | `REQ-*`, `NS-*`, `ASM-*`, `CON-*`, `SC-*`, `NEG-*`, `CHK-*`, `EVID-*` | Update `brief.md` first |
+| `design.md` | canonical solution owner | `SOL-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` | Update `design.md` or ADR first |
+| `decision-log.md` | decision provenance | `FDL-*`, FPF rationale and accepted feature-local decisions | Update `decision-log.md` and owner doc before execution continues |
+| `none` | optional support docs | No feature-support docs are required for this documentation-only feature. | Create support docs only if implementation discovers real ambiguity that cannot be captured by owner docs |
+
+## Current State / Reference Points
+
+| Path / module | Current role | Why relevant | Reuse / mirror |
+| --- | --- | --- | --- |
+| `memory-bank/engineering/frontend.md` | Canonical frontend engineering guidance | Issue 17 requires linking the optional design guide with frontend guidance. | Add a concise optional companion route; do not move frontend contract ownership. |
+| `memory-bank/engineering/README.md` | Engineering documentation index | The optional guide must be discoverable from the engineering layer. | Add annotated optional child link. |
+| `memory-bank/domain/README.md` | Domain owner boundary | It explicitly excludes UI design system ownership. | Do not create `domain/design-guide` as generic owner. |
+| `memory-bank/flows/templates/README.md` | Template wrapper index | Used to confirm no separate flow-template artifact is required for the selected optional engineering destination. | Do not modify unless `design.md` is updated first. |
+| `scripts/check_memory_bank_index.py` | Link/reachability audit | Required by repository checks. | Run after docs are added. |
+
+## Test Strategy
+
+| Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites / commands | Required CI suites / jobs | Manual-only gap / justification | Manual-only approval ref |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Markdown navigation and frontmatter dependencies | `REQ-01`, `REQ-03`, `CHK-01`, `SOL-02` | `scripts/check_memory_bank_index.py` audits links, reachability and README index contracts. | Use existing script; add no new code tests unless script reveals a reusable gap. | `python3 scripts/check_memory_bank_index.py` | Same command if CI exists; otherwise local evidence is sufficient for docs-only feature. | none | none |
+| Generic UI guide content | `REQ-02`, `REQ-04`, `NEG-01`, `CHK-02`, `SOL-01`, `SOL-03` | No existing dedicated guide. | Targeted `rg` and manual review against required sections and framework-specific defaults. | `rg -n "components|forms|buttons|actions|tables|navigation|states|labels|screenshots|source code paths|agent instructions" memory-bank/engineering` plus targeted source-framework guard on new generic docs | Same command if CI exists; otherwise local evidence is sufficient for docs-only feature. | Manual semantic review is required to confirm no copied downstream content; this is acceptable because the repo has no semantic linter. | none |
+| Diff hygiene and owner boundaries | `REQ-03`, `REQ-04`, `CHK-03`, `INV-01`, `INV-02` | `git diff --check`; manual owner-boundary review. | Use existing git check and review touched docs. | `git diff --check` | Same command if CI exists; otherwise local evidence is sufficient for docs-only feature. | Manual owner-boundary review is required. | none |
+
+## Open Questions / Ambiguities
+
+No unresolved blocking questions remain after [`decision-log.md`](decision-log.md):
+
+| Open Question ID | Question | Why unresolved | Blocks | Default action / escalation owner |
+| --- | --- | --- | --- | --- |
+| `OQ-00` | none | FPF decisions `FDL-001` through `FDL-004` closed the material owner/location questions. | none | If implementation discovers a new owner-boundary conflict, stop and update `brief.md` / `design.md` before continuing. |
+
+## Environment Contract
+
+| Area | Contract | Used by | Failure symptom |
+| --- | --- | --- | --- |
+| setup | Work from repository root with Python 3 and `rg` available. | `STEP-01`, `STEP-02`, `STEP-03` | Verification commands cannot run or inspect expected paths. |
+| test | Repository-local docs checks are authoritative for this docs-only feature. | `CHK-01`, `CHK-02`, `CHK-03` | Broken links, missing index annotations, whitespace errors or framework-specific defaults in target generic docs. |
+| access / network / secrets | No network or secrets are required to implement docs. | all steps | Any required external source lookup means scope has changed and must be escalated. |
+
+## Preconditions
+
+| Precondition ID | Canonical ref | Required state | Used by steps | Blocks start |
+| --- | --- | --- | --- | --- |
+| `PRE-01` | `brief.md`, `design.md`, `decision-log.md` | Upstream owner docs are active and agree on engineering-layer optional guide. | `STEP-01`, `STEP-02` | yes |
+| `PRE-02` | `REQ-04`, `SOL-03`, `CTR-03` | Implementer accepts that source-project framework rules are not generic defaults. | `STEP-01`, `STEP-03` | yes |
+
+## Workstreams
+
+| Workstream | Implements | Result | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| `WS-1` | `REQ-01`, `REQ-02`, `SOL-01`, `SOL-03` | Optional UI design guide destination/template added with required sections and generic guardrails. | agent | `PRE-01`, `PRE-02` |
+| `WS-2` | `REQ-03`, `SOL-02`, `CTR-02` | `frontend.md` and README/index routes make the optional guide discoverable. | agent | `WS-1` |
+| `WS-3` | `REQ-04`, `CHK-01`, `CHK-02`, `CHK-03` | Verification evidence proves link integrity, optionality and generic content safety. | agent | `WS-1`, `WS-2` |
+
+## Approval Gates
+
+No human approval gate is required for the planned docs-only edits.
+
+| Approval Gate ID | Trigger | Applies to | Why approval is required | Approver / evidence |
+| --- | --- | --- | --- | --- |
+| `AG-00` | none | none | No risky, irreversible, costly or external-effect operation is planned. | none |
+
+## Порядок работ
+
+| Step ID | Actor | Implements | Goal | Touchpoints | Artifact | Verifies | Evidence IDs | Check command / procedure | Blocked by | Needs approval | Escalate if |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `STEP-01` | agent | `REQ-01`, `REQ-02`, `REQ-04`, `SOL-01`, `SOL-03` | Add optional UI design guide destination/template with generic prompts and required sections. | `memory-bank/engineering/ui-design-guide/README.md` | New optional guide doc | `CHK-02` | `EVID-02` | Review required section list and targeted source-framework guard. | `PRE-01`, `PRE-02` | none | The guide needs project-specific framework rules to be useful. |
+| `STEP-02` | agent | `REQ-03`, `SOL-02`, `CTR-02` | Route readers from frontend/index docs to the optional guide. | `memory-bank/engineering/frontend.md`, `memory-bank/engineering/README.md` | Updated annotated links | `CHK-01`, `CHK-03` | `EVID-01`, `EVID-03` | Run index audit and inspect optional wording. | `STEP-01` | none | A routing change would make the optional guide mandatory. |
+| `STEP-03` | agent | `REQ-01`, `REQ-02`, `REQ-03`, `REQ-04` | Verify and record evidence for delivery. | repository docs and evidence paths | Verification logs / notes | `CHK-01`, `CHK-02`, `CHK-03` | `EVID-01`, `EVID-02`, `EVID-03` | `python3 scripts/check_memory_bank_index.py`; `git diff --check`; targeted `rg`; manual owner-boundary review. | `STEP-01`, `STEP-02` | none | Checks reveal contradictions with `brief.md`, `design.md` or existing governance docs. |
+
+## Parallelizable Work
+
+- `PAR-01` `STEP-01` and `STEP-02` should not be parallelized because routing links depend on the final optional guide path.
+- `PAR-02` `CHK-01`, `CHK-02` and `CHK-03` can run in any order after `STEP-01` and `STEP-02`.
+
+## Checkpoints
+
+| Checkpoint ID | Refs | Condition | Evidence IDs |
+| --- | --- | --- | --- |
+| `CP-01` | `STEP-01`, `REQ-01`, `REQ-02`, `SOL-01` | Optional guide exists with all required sections and generic guardrails. | `EVID-02` |
+| `CP-02` | `STEP-02`, `REQ-03`, `SOL-02` | Routing docs link to the guide and mark it optional. | `EVID-01`, `EVID-03` |
+| `CP-03` | `STEP-03`, `CHK-01`, `CHK-02`, `CHK-03` | Verification commands and manual review pass. | `EVID-01`, `EVID-02`, `EVID-03` |
+
+## Execution Risks
+
+| Risk ID | Risk | Impact | Mitigation | Trigger |
+| --- | --- | --- | --- | --- |
+| `ER-01` | The new guide becomes a second owner for frontend engineering policy. | Contradiction with `frontend.md` and `INV-01`. | Keep guide as concrete UI kit reference and route back to `frontend.md` for engineering contract. | Guide starts defining global frontend architecture, stack migration or component ownership policy. |
+| `ER-02` | Source-specific framework names or rules leak into target generic docs. | Violates `REQ-04` and `NEG-01`. | Use generic placeholders and targeted content guard. | Target guide prescribes source stack choices. |
+| `ER-03` | Index audit requires additional reachability links. | Incomplete discoverability or failed repository check. | Add the minimum annotated README/index route consistent with optionality. | `check_memory_bank_index.py` reports unreachable docs or index contract failures. |
+
+## Stop Conditions / Fallback
+
+| Stop ID | Related refs | Trigger | Immediate action | Safe fallback state |
+| --- | --- | --- | --- | --- |
+| `STOP-01` | `REQ-04`, `FDL-004`, `FM-01` | Implementation cannot satisfy usefulness without copying source-project framework rules. | Stop and raise human gate with alternatives. | Keep feature docs active, no generic guide change. |
+| `STOP-02` | `INV-01`, `INV-02`, `FM-03` | Existing owner documents contradict the selected engineering-layer destination. | Stop and update `brief.md` / `design.md` or request human decision. | Keep `frontend.md` unchanged. |
+
+## Plan-local Evidence
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checkpoints |
+| --- | --- | --- | --- | --- |
+| `EVID-09` | Discovery and review-improve notes for feature-doc readiness | implementer / reviewer | `memory-bank/features/FT-017/feature-review-report.md` | `CP-01`, `CP-02`, `CP-03` |
+
+## Execution Result
+
+| Checkpoint ID | Result | Evidence |
+| --- | --- | --- |
+| `CP-01` | pass | `memory-bank/features/FT-017/evidence/chk-02/result.txt` |
+| `CP-02` | pass | `memory-bank/features/FT-017/evidence/chk-01/result.txt`, `memory-bank/features/FT-017/evidence/chk-03/result.txt` |
+| `CP-03` | pass | `memory-bank/features/FT-017/evidence/chk-01/result.txt`, `memory-bank/features/FT-017/evidence/chk-02/result.txt`, `memory-bank/features/FT-017/evidence/chk-03/result.txt` |
+
+## Готово для приемки
+
+- All workstreams are complete or explicitly stopped through `STOP-*`.
+- All checkpoints have evidence.
+- Required local suites are green, and CI does not contradict local verify.
+- Manual-only semantic review is recorded in `EVID-02` or `EVID-03`.
+- Support docs, if later added, do not disagree with `brief.md`, `decision-log.md`, `design.md` or this plan.
+- Final acceptance follows `brief.md` `Verify`, not this checklist.

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -29,3 +29,8 @@ audience: humans_and_agents
 - Базовый формат: `FT-XXX/`
 - Вместо `XXX` используй идентификатор, принятый в проекте: issue id, ticket id или другой стабильный ключ
 - Один package = одна delivery-единица
+
+## Active Feature Packages
+
+- [`FT-017`](FT-017/README.md)
+  Читать, когда нужно: вести issue 17 про optional UI design guide pattern для frontend/admin UI через feature-flow.


### PR DESCRIPTION
## Summary

- Add an optional `memory-bank/engineering/ui-design-guide/README.md` destination/template for documenting existing UI kits.
- Link the guide from `engineering/frontend.md` and `engineering/README.md` while keeping it optional and engineering-scoped.
- Add FT-017 feature package, FPF decision log, implementation plan, review report, and verification evidence.

## Why

Projects with existing frontend/admin UI need a fast source of truth for components, forms, actions, tables, navigation, states, screenshots, source paths, helper APIs, and agent instructions without copying project-specific UI framework assumptions into the generic template.

Closes #17

## Checks

- `python3 scripts/check_memory_bank_index.py`
- `git diff --check`
- `rg --files memory-bank | sort`
- `rg -n "components|forms|buttons|actions|tables|navigation|states|labels|screenshots|source code paths|agent instructions" memory-bank/engineering/ui-design-guide/README.md memory-bank/engineering/frontend.md memory-bank/engineering/README.md`
- `rg -n "brandymint|merchantly|Inspinia|HAML" memory-bank --glob '!memory-bank/features/FT-017/**'`\n\n## Notes\n\nThe source project references from issue #17 are treated as evidence of need only; no downstream framework-specific defaults were promoted into the generic memory-bank template.