### PR TITLE
[codex] Add workflow routing metrics and decision log

### DIFF
--- a/memory-bank/features/FT-013/README.md
+++ b/memory-bank/features/FT-013/README.md
@@ -1,0 +1,33 @@
+---
+title: "FT-013: Workflow Routing Metrics And Decision Log"
+doc_kind: feature
+doc_function: index
+purpose: "Навигация по feature package для issue 13. Читать, чтобы перейти к canonical brief, selected design, execution plan и feature-local decision log."
+derived_from:
+  - ../../dna/governance.md
+  - brief.md
+  - design.md
+  - implementation-plan.md
+  - decision-log.md
+status: active
+audience: humans_and_agents
+---
+# FT-013: Workflow Routing Metrics And Decision Log
+
+## О разделе
+
+Этот package ведет issue 13 по `feature-flow`: добавить generic workflow decision log, workflow metrics template и developer brief для workflow selector-а без переноса project-specific деталей из source repo.
+
+## Аннотированный индекс
+
+- [brief.md](brief.md)
+  Читать, когда нужно: проверить problem space, scope/non-scope, assumptions, constraints и canonical verify contract для delivery-единицы.
+
+- [design.md](design.md)
+  Читать, когда нужно: проверить selected solution, C4 applicability, local decisions, contracts, invariants, failure modes и rollout/backout для набора workflow-документов.
+
+- [implementation-plan.md](implementation-plan.md)
+  Читать, когда нужно: выполнить реализацию issue 13 по шагам, touchpoints, checkpoints и verify strategy.
+
+- [decision-log.md](decision-log.md)
+  Читать, когда нужно: увидеть FPF-backed решения, принятые при подготовке и review-improve feature package.

--- a/memory-bank/features/FT-013/brief.md
+++ b/memory-bank/features/FT-013/brief.md
@@ -1,0 +1,137 @@
+---
+title: "FT-013: Workflow Routing Metrics And Decision Log"
+doc_kind: feature
+doc_function: canonical
+purpose: "Canonical brief для issue 13. Фиксирует problem space, scope и verify contract для generic workflow routing metrics, decision log и developer brief."
+derived_from:
+  - ../../flows/feature-flow.md
+  - ../../flows/workflows.md
+  - ../../engineering/testing-policy.md
+status: active
+delivery_status: in_progress
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - solution_space
+---
+# FT-013: Workflow Routing Metrics And Decision Log
+
+## What
+
+### Problem
+
+Если в generic memory-bank вводятся compact workflow profiles, нужен проверяемый способ понять, снизили ли они лишнюю documentation ceremony без потери safety, evidence и traceability. Issue 13 указывает на source pattern из `alfagen/mercury`: workflow decision log, workflow metrics и workflow routing developer brief. Текущий шаблон уже имеет [Task Workflows](../../flows/workflows.md), но не имеет generic optional документов для фиксации причин изменения selector-а, измерения safety-first outcomes и краткого объяснения workflow profiles разработчикам.
+
+Feature должна адаптировать source pattern в generic шаблон: сохранить полезную структуру, но не переносить source repo names, project-specific dates, operational details или локальные команды downstream-проекта.
+
+### Outcome
+
+| Metric ID | Metric | Baseline | Target | Measurement method |
+| --- | --- | --- | --- | --- |
+| `MET-01` | Safety-first workflow evaluation | Метрик workflow selector-а в шаблоне нет | Метрики явно оценивают safety/evidence/rework/traceability раньше speed | Review `workflow-metrics.md` decision rule и metric cards |
+| `MET-02` | Decision rationale auditability | Причины изменений selector-а не имеют dedicated generic owner-а | Decision log объясняет зачем появился selector, какие решения приняты и как их пересматривать | Review `workflow-decision-log.md` structure |
+| `MET-03` | Developer routing clarity | `workflows.md` описывает типы workflow, но нет короткого developer brief/template для workflow profiles | Короткий developer-facing doc объясняет выбор profiles и escalation/promotion triggers | Review `workflow-routing-developer-brief.md` |
+| `MET-04` | Navigation reachability | Optional workflow docs отсутствуют в `flows/README.md` | Новые optional docs reachable из `flows/README.md` и согласованы с `workflows.md` | `python3 scripts/check_memory_bank_index.py` |
+
+### Scope
+
+- `REQ-01` Добавить generic workflow decision log для причин изменения workflow selector-а, ожидаемых последствий и review/update правил.
+- `REQ-02` Добавить workflow metrics template/document, покрывающий routing coverage, safety misroute, missing evidence, rework и traceability; speed может быть только вторичным измерением.
+- `REQ-03` Добавить короткий developer brief или template, объясняющий выбор workflow profiles и когда нужно повышать задачу до более строгого flow.
+- `REQ-04` Связать новые optional docs с `memory-bank/flows/README.md` и `memory-bank/flows/workflows.md` без broken links.
+- `REQ-05` Зафиксировать связь с task-flow issue 12 как зависимость/adjacent scope, не реализуя `task-flow`, `bugfix-flow` или `refactor-flow` в рамках FT-013.
+- `REQ-06` Адаптировать source pattern generic-образом: не переносить source repo names, project-specific dates, operational commands или downstream-specific details в reusable docs.
+
+### Non-Scope
+
+- `NS-01` Не реализовывать issue 12: `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`, `TASK-XXX` templates и `memory-bank/tasks/README.md`.
+- `NS-02` Не менять `feature-flow.md` lifecycle, stable IDs или feature package templates.
+- `NS-03` Не вводить project-level product KPI в `memory-bank/product/metrics.md`; workflow metrics остаются process-layer guidance.
+- `NS-04` Не задавать fixed pilot dates, repository-specific thresholds или operational commands как generic defaults.
+- `NS-05` Не мигрировать существующие tasks/features и не создавать downstream project examples.
+
+### Constraints / Assumptions
+
+- `ASM-01` Source docs from `alfagen/mercury` are evidence for reusable structure, not content to copy verbatim.
+- `ASM-02` Issue 12 is the owner for compact task-flow implementation; FT-013 may reference that dependency but must not create its artifacts.
+- `ASM-03` Current repo has no local `task-flow.md`, `bugfix-flow.md` or `refactor-flow.md`; implementation must avoid links to absent local files.
+- `CON-01` Generic memory-bank must not receive source project names, source pilot dates, local operational commands or downstream domain details.
+- `CON-02` New workflow docs are optional guidance, but must be reachable from `flows/README.md`.
+- `CON-03` Metrics must measure safety/evidence before speed.
+- `CON-04` Review and verify must use existing lightweight repository checks: link audit, whitespace/conflict-marker check and targeted leak scan.
+
+No unresolved blocking `DEC-*` remain after feature-local decisions in [decision-log.md](decision-log.md).
+
+## Design Requirement Decision
+
+| Decision | Reason | Downstream owner |
+| --- | --- | --- |
+| `Design required: yes` | The feature chooses owners/locations for new governance docs, resolves the open task-flow dependency, and sets safety-first metric semantics. These are solution-space decisions, not execution steps. | `design.md` |
+
+## Verify
+
+### Exit Criteria
+
+- `EC-01` `memory-bank/flows/workflow-decision-log.md` exists, is generic, and explains why selector changes are introduced, how decisions are reviewed, and what must be recorded.
+- `EC-02` `memory-bank/flows/workflow-metrics.md` exists and includes routing coverage, safety misroute, missing evidence, rework, traceability and a decision rule where safety gates precede speed.
+- `EC-03` `memory-bank/flows/workflow-routing-developer-brief.md` exists and gives a short, reusable explanation of workflow profile choice and promotion/escalation triggers.
+- `EC-04` `memory-bank/flows/README.md` and `memory-bank/flows/workflows.md` make the optional docs reachable without linking to absent local task-flow files.
+- `EC-05` Generic docs do not contain source project names, source pilot dates, source operational commands or downstream-specific implementation details.
+- `EC-06` `python3 scripts/check_memory_bank_index.py` and `git diff --check` pass.
+
+### Traceability matrix
+
+| Requirement ID | Problem refs | Acceptance refs | Checks | Evidence IDs |
+| --- | --- | --- | --- | --- |
+| `REQ-01` | `ASM-01`, `CON-01`, `CON-02` | `EC-01`, `SC-02` | `CHK-01`, `CHK-03`, `CHK-04` | `EVID-01`, `EVID-03`, `EVID-04` |
+| `REQ-02` | `CON-03` | `EC-02`, `SC-02`, `NEG-01` | `CHK-01`, `CHK-04` | `EVID-01`, `EVID-04` |
+| `REQ-03` | `ASM-01`, `ASM-03` | `EC-03`, `SC-01` | `CHK-01`, `CHK-04` | `EVID-01`, `EVID-04` |
+| `REQ-04` | `CON-02`, `ASM-03` | `EC-04`, `SC-01` | `CHK-01` | `EVID-01` |
+| `REQ-05` | `ASM-02`, `ASM-03` | `EC-04`, `SC-01` | `CHK-01`, `CHK-04` | `EVID-01`, `EVID-04` |
+| `REQ-06` | `ASM-01`, `CON-01` | `EC-05`, `SC-03`, `NEG-02` | `CHK-02`, `CHK-03`, `CHK-04` | `EVID-02`, `EVID-03`, `EVID-04` |
+
+### Acceptance Scenarios
+
+- `SC-01` Developer or agent starts from `flows/README.md` or `workflows.md`, finds optional workflow routing docs, and can understand profile choice and escalation without needing source repo context.
+- `SC-02` Maintainer reviews a workflow selector change and uses decision log plus metrics to evaluate whether compact profiles improved ceremony without weakening safety/evidence.
+- `SC-03` Reviewer checks the delivered generic docs and finds no source repo names, source pilot dates, source operational commands or downstream-specific assumptions.
+
+### Negative / Edge Scenarios
+
+- `NEG-01` If lead time improves but safety misroutes, missing evidence or rework get worse, workflow metrics must not classify the selector change as successful.
+- `NEG-02` If source docs include project-specific names, dates or commands, delivered generic docs must omit or replace them with generic placeholders/rules.
+- `NEG-03` If issue 12 is not implemented, FT-013 docs must still pass link audit by avoiding local links to absent `task-flow.md`, `bugfix-flow.md` or `refactor-flow.md`.
+
+### Checks
+
+| Check ID | Covers | How to check | Expected result | Evidence path |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `EC-01`, `EC-02`, `EC-03`, `EC-04`, `NEG-03` | `python3 scripts/check_memory_bank_index.py` | No broken links, orphan docs, unreachable docs or index contract failures | `artifacts/ft-013/verify/chk-01/` |
+| `CHK-02` | `EC-06` | `git diff --check` | No trailing whitespace or conflict markers | `artifacts/ft-013/verify/chk-02/` |
+| `CHK-03` | `EC-05`, `NEG-02` | `rg -n "Mercury|alfagen|2026-06-29|2026-07-28|2026-07-29|dip|Rails|Rake|RSpec|MySQL" memory-bank/flows/workflow-*.md` | No matches in delivered generic workflow docs | `artifacts/ft-013/verify/chk-03/` |
+| `CHK-04` | `EC-01`..`EC-05` | Manual review against issue 13, issue 12 dependency, `design.md` traceability and source pattern summary | Reviewer can trace every delivered doc to `REQ-*` and sees task-flow dependency handled without scope expansion | `artifacts/ft-013/verify/chk-04/` |
+
+### Test matrix
+
+| Check ID | Evidence IDs | Evidence path |
+| --- | --- | --- |
+| `CHK-01` | `EVID-01` | `artifacts/ft-013/verify/chk-01/` |
+| `CHK-02` | `EVID-02` | `artifacts/ft-013/verify/chk-02/` |
+| `CHK-03` | `EVID-03` | `artifacts/ft-013/verify/chk-03/` |
+| `CHK-04` | `EVID-04` | `artifacts/ft-013/verify/chk-04/` |
+
+### Evidence
+
+- `EVID-01` Link audit output proving new docs are reachable and internally valid.
+- `EVID-02` Whitespace/conflict-marker check output.
+- `EVID-03` Targeted leak scan output for source project names, dates and operational commands in delivered workflow docs.
+- `EVID-04` Reviewer note or PR description section mapping issue 13 acceptance to delivered docs.
+
+### Evidence contract
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checks |
+| --- | --- | --- | --- | --- |
+| `EVID-01` | Link audit command output | implementer | `artifacts/ft-013/verify/chk-01/` or PR check log | `CHK-01` |
+| `EVID-02` | `git diff --check` output | implementer | `artifacts/ft-013/verify/chk-02/` or PR check log | `CHK-02` |
+| `EVID-03` | Leak scan output | implementer | `artifacts/ft-013/verify/chk-03/` or PR check log | `CHK-03` |
+| `EVID-04` | Manual traceability review note | reviewer / implementer | `artifacts/ft-013/verify/chk-04/` or PR body | `CHK-04` |

--- a/memory-bank/features/FT-013/decision-log.md
+++ b/memory-bank/features/FT-013/decision-log.md
@@ -1,0 +1,127 @@
+---
+title: "FT-013: Decision Log"
+doc_kind: feature-support
+doc_function: decision_log
+purpose: "Feature-local decision log for FPF-backed decisions made while preparing and reviewing FT-013 documents."
+derived_from:
+  - brief.md
+  - ../../flows/feature-flow.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_013_scope
+  - ft_013_acceptance_criteria
+  - implementation_sequence
+---
+# FT-013: Decision Log
+
+## DL-FT013-001: Require `design.md` for this docs-only feature
+
+**Date:** 2026-07-08
+
+**Question:** Does FT-013 need a separate solution-space owner even though it changes only documentation?
+
+**Available facts:**
+
+- Issue 13 requires three reusable workflow documents and links to `flows/workflows.md` plus task-flow issue.
+- `feature-flow.md` requires `design.md` when a feature needs alternatives/trade-off reasoning or otherwise would force `implementation-plan.md` to make design decisions.
+- FT-013 must decide document locations, optional-vs-canonical semantics, source adaptation rules and how to handle absent task-flow docs.
+
+**FPF reasoning:** By Bounded Context, the reusable flow docs, feature package and GitHub issues are separate semantic frames; their links must be explicit. By Strict Distinction, `brief.md` owns problem facts and `implementation-plan.md` owns execution sequencing, so solution choices need their own owner.
+
+**Decision:** `Design required: yes`; create `design.md` as the owner of selected solution, alternatives, trade-offs, contracts and invariants.
+
+**Consequences:**
+
+- `brief.md` remains problem/verify owner.
+- `implementation-plan.md` can stay execution-only.
+- Solution choices are traceable via `SOL-*`, `SD-*`, `CTR-*`, `INV-*` and `FM-*`.
+
+## DL-FT013-002: Treat issue 12 as adjacent dependency, not FT-013 scope
+
+**Date:** 2026-07-08
+
+**Question:** How should FT-013 "link with task-flow issue" when `task-flow.md`, `bugfix-flow.md` and `refactor-flow.md` do not exist in this repo yet?
+
+**Available facts:**
+
+- Issue 13 scope says to connect workflow metrics/decision log/developer brief with `flows/workflows.md` and task-flow issue.
+- GitHub issue 12 is open and owns `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`, task templates and `memory-bank/tasks/README.md`.
+- Current repository search shows no local `task-flow.md`, `bugfix-flow.md` or `refactor-flow.md`.
+- `check_memory_bank_index.py` fails broken internal links.
+
+**FPF reasoning:** Bounded Context keeps FT-013 and issue 12 as separate delivery contexts. Strict Distinction prevents a dependency reference from becoming implementation work. Evidence Graph discipline requires actual local carriers before local links can be treated as valid evidence.
+
+**Decision:** FT-013 records issue 12 as an adjacent dependency and non-scope boundary. Generic docs must not link to absent local task-flow files; they may describe compact profiles generically and be updated after issue 12 lands.
+
+**Consequences:**
+
+- No `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`, task templates or `memory-bank/tasks/` are created in FT-013.
+- Link audit remains enforceable.
+- A future issue/PR may add concrete task-flow links after issue 12 is implemented.
+
+## DL-FT013-003: Safety metrics outrank speed metrics
+
+**Date:** 2026-07-08
+
+**Question:** How should workflow metrics decide whether compact profiles succeeded?
+
+**Available facts:**
+
+- Issue 13 acceptance says metrics must measure safety before speed.
+- Source pattern includes routing coverage, safety misroute, missing evidence, rework, traceability and lead-time style measurements.
+- `testing-policy.md` requires evidence and regression/safety coverage where deterministic verification is realistic.
+
+**FPF reasoning:** Evidence Graph says claims need a carrier chain; Trust & Assurance says assurance is capped by weakest supported evidence and integration fit. Therefore faster workflow throughput cannot compensate for missing evidence, wrong routing or unsafe profile selection.
+
+**Decision:** `workflow-metrics.md` must order decision rules so safety/evidence/rework/traceability gates are evaluated before speed/lead-time. Speed is a secondary observation and cannot produce success when safety gates fail.
+
+**Consequences:**
+
+- `NEG-01` becomes canonical in `brief.md`.
+- `INV-02` and `SD-02` require safety-first metric semantics.
+- Implementation must avoid wording that presents speed improvement as sufficient success.
+
+## DL-FT013-004: Generic adaptation, not source import
+
+**Date:** 2026-07-08
+
+**Question:** How much of the `alfagen/mercury` source pattern can be reused in generic memory-bank docs?
+
+**Available facts:**
+
+- Issue 13 cites three source docs as useful pattern evidence.
+- Issue 13 explicitly says not to transfer project-specific dates, project names or operational details.
+- Source docs include concrete pilot dates, source repo/project names and local operational commands/details.
+
+**FPF reasoning:** Evidence Graph allows source carriers to support a claim about useful structure, but Bounded Context forbids silently moving local invariants and operational details into the generic template context. Strict Distinction separates evidence source from reusable generic content.
+
+**Decision:** Reuse only the generic structure and concepts: decision entries, metric cards, safety-first decision rule and developer brief shape. Replace project-specific dates, names, commands and local assumptions with generic placeholders or configurable fields.
+
+**Consequences:**
+
+- `CHK-03` targets source leakage in delivered workflow docs.
+- `CTR-04` makes generic adaptation a solution contract.
+- Reviewer acceptance must include a semantic check, not only a string scan.
+
+## DL-FT013-005: Keep decision-log provenance acyclic
+
+**Date:** 2026-07-08
+
+**Question:** Should `design.md` derive from `decision-log.md`, and should `decision-log.md` derive from `design.md`?
+
+**Available facts:**
+
+- The first package draft linked `design.md` and `decision-log.md` through reciprocal `derived_from` entries.
+- `feature-flow.md` makes `design.md` the solution-space owner and allows support docs only as aids that do not replace canonical owners.
+- `decision-log.md` records feature-local reasoning used to support owner documents; it is not itself the selected solution owner.
+
+**FPF reasoning:** Evidence Graph discipline favors acyclic provenance chains. Strict Distinction separates the canonical solution episteme (`design.md`) from its support/provenance carrier (`decision-log.md`). A support log can be linked from README and cited in prose without becoming an upstream dependency of the canonical design frontmatter.
+
+**Decision:** Remove the reciprocal `derived_from` edge. `design.md` derives from `brief.md`; `decision-log.md` derives from `brief.md` and `feature-flow.md`.
+
+**Consequences:**
+
+- The package keeps decision provenance visible through README and body links.
+- Frontmatter dependency graph remains acyclic and owner boundaries are clearer.
+- Future review-improve entries can be appended to `decision-log.md` without changing canonical design dependencies unless they alter selected solution facts.

--- a/memory-bank/features/FT-013/design.md
+++ b/memory-bank/features/FT-013/design.md
@@ -1,0 +1,115 @@
+---
+title: "FT-013: Design"
+doc_kind: feature
+doc_function: canonical
+purpose: "Solution-space документ для FT-013. Фиксирует выбранный подход к workflow decision log, workflow metrics и developer brief без переопределения problem space или execution contract."
+derived_from:
+  - brief.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_013_scope
+  - ft_013_acceptance_criteria
+  - ft_013_evidence_contract
+  - implementation_sequence
+---
+# FT-013: Design
+
+## Design Pack
+
+| Artifact | Role | Owns |
+| --- | --- | --- |
+| `design.md` | Feature-local solution owner | `SOL-*`, `ALT-*`, `TRD-*`, `C4-*`, feature-local `CTR-*`, `INV-*`, `FM-*`, `RB-*` |
+| `decision-log.md` | Feature-local decision provenance | FPF-backed `DL-FT013-*` decisions used by this design |
+
+## Context
+
+Issue 13 asks to adapt a proven source pattern into the generic memory-bank template: workflow decision log, workflow metrics and developer brief for workflow selector-а. Current `flows/workflows.md` provides coarse task routing, while issue 12 owns the future compact task-flow, bugfix-flow and refactor-flow artifacts. FT-013 therefore needs a solution that adds optional, reachable process docs now without silently implementing issue 12 or adding broken links to absent local files.
+
+The design problem is not runtime architecture. It is documentation ownership: where the new process docs live, how generic they must be, how safety-first metrics are expressed, and how the issue 12 dependency is represented.
+
+## C4 Applicability
+
+| C4 ID | Decision | Trigger / reason | Artifact |
+| --- | --- | --- | --- |
+| `C4-00` | `not required` | The feature changes markdown governance/process docs only. It does not change API, schema, runtime topology, deployable/container boundaries, security boundary, queue/storage or external integration. | `none` |
+
+## Selected Solution
+
+- `SOL-01` Add `memory-bank/flows/workflow-decision-log.md` as an optional governed process document. It owns workflow selector rationale, decision entries and review/update rules for selector/profile changes.
+- `SOL-02` Add `memory-bank/flows/workflow-metrics.md` as an optional governed metrics template. It owns metric cards and decision rules for evaluating workflow profile changes, with safety/evidence gates before speed.
+- `SOL-03` Add `memory-bank/flows/workflow-routing-developer-brief.md` as a short developer-facing guide/template. It explains workflow profile choice, promotion triggers and expected evidence at a level that stays usable before issue 12 lands.
+- `SOL-04` Update `memory-bank/flows/README.md` so the optional docs are reachable from the flows index.
+- `SOL-05` Update `memory-bank/flows/workflows.md` with a compact pointer from routing rules to the optional decision log, metrics and developer brief.
+- `SOL-06` Keep issue 12 as an explicit adjacent dependency in FT-013 docs and implementation notes, but do not create `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`, task templates or `memory-bank/tasks/`.
+
+## Alternatives Considered
+
+| Alternative ID | Option | Why not selected |
+| --- | --- | --- |
+| `ALT-01` | Copy source docs into `memory-bank/flows/` verbatim | Rejected because issue 13 explicitly forbids project-specific dates, project names and operational details. |
+| `ALT-02` | Put all three docs under `memory-bank/flows/templates/` only | Rejected because issue and source pattern point to reusable flow-level docs, and acceptance requires optional docs reachable from `flows/README.md`; putting them only under templates would hide them from routing use. |
+| `ALT-03` | Wait for issue 12 before adding any workflow routing metrics/docs | Rejected because issue 13 can deliver generic optional evaluation/rationale docs now, as long as it avoids local links to absent task-flow artifacts. |
+| `ALT-04` | Add task-flow, bugfix-flow and refactor-flow links speculatively | Rejected because those files do not exist in current repo and issue 12 owns their creation. This would fail link audit and expand scope. |
+
+## Trade-offs
+
+| Trade-off ID | Decision | Benefit | Cost / Risk |
+| --- | --- | --- | --- |
+| `TRD-01` | Keep docs in `flows/` rather than only `flows/templates/` | High discoverability from routing docs and direct reuse by downstream projects | Docs must be written as generic guidance with placeholders, not as instantiated project pilot records |
+| `TRD-02` | Use configurable placeholders/examples instead of source pilot dates and fixed thresholds | Avoids leaking source operational context into the generic template | Downstream projects must set concrete dates/thresholds during adoption |
+| `TRD-03` | Mention compact profiles generically before issue 12 lands | Lets developer brief explain the selector intent now | Requires careful wording to avoid promising local docs that are not present yet |
+
+## Accepted Local Decisions
+
+- `SD-01` FT-013 creates a feature-local `decision-log.md` for FPF-backed documentation decisions made during package creation and review-improve.
+- `SD-02` `workflow-metrics.md` must treat speed/lead-time as a secondary observation; any safety misroute or missing critical evidence blocks a positive success verdict.
+- `SD-03` Generic workflow docs must not link to absent local `task-flow.md`, `bugfix-flow.md` or `refactor-flow.md`. If issue 12 later adds them, a follow-up may add concrete links.
+- `SD-04` `workflow-routing-developer-brief.md` is a reusable guide/template, not a project-specific announcement. It may describe profile families in generic terms and point to existing canonical `workflows.md`, `feature-flow.md` and `epic-flow.md`.
+
+## Contracts
+
+| Contract ID | Input / Output | Producer / Consumer | Semantics / Constraints |
+| --- | --- | --- | --- |
+| `CTR-01` | New `workflow-*.md` docs under `memory-bank/flows/` | Implementer / flows readers | Each doc has YAML frontmatter, `status`, relative `derived_from` only to existing local docs, and no broken internal links. |
+| `CTR-02` | `flows/README.md` navigation | Implementer / link audit and readers | The index includes annotated links to the optional workflow docs. |
+| `CTR-03` | `workflows.md` routing pointer | Implementer / agents choosing workflow | Routing rules point readers to decision log, metrics and developer brief as optional aids without making them mandatory lifecycle gates. |
+| `CTR-04` | Generic adaptation boundary | Implementer / reviewers | Delivered workflow docs omit source project names, source pilot dates, source operational commands and downstream-specific domain details. |
+
+## Invariants
+
+- `INV-01` Optional workflow docs must not become required gates for every task unless a future governance change explicitly promotes them.
+- `INV-02` Safety/evidence metrics outrank speed metrics in any selector success decision.
+- `INV-03` Task-flow issue 12 remains the owner for compact task-flow artifacts.
+- `INV-04` Feature-flow docs remain unchanged by FT-013 unless a future issue explicitly changes lifecycle rules.
+
+## Failure Modes
+
+- `FM-01` If new docs link to absent task-flow files, `check_memory_bank_index.py` fails. Mitigation: link only existing local docs and represent issue 12 dependency in feature docs, not reusable flow docs.
+- `FM-02` If metrics reuse source pilot dates or commands as defaults, generic template quality fails. Mitigation: use placeholders, configurable windows and generic evidence sources.
+- `FM-03` If `workflow-routing-developer-brief.md` repeats detailed issue 12 scope, FT-013 expands beyond its boundary. Mitigation: keep profile descriptions generic and leave task-flow artifacts to issue 12.
+
+## Rollout / Backout
+
+| Stage ID | Stage | Entry condition | Backout |
+| --- | --- | --- | --- |
+| `RB-01` | Add workflow docs and navigation | `brief.md` and `design.md` active | Remove new `workflow-*.md` docs and README/workflows links if link audit or generic leak scan fails and cannot be fixed locally |
+| `RB-02` | Verify generic adaptation | New docs exist | Revert or rewrite project-specific fragments before handoff |
+
+## ADR / External Design Dependencies
+
+| Artifact | Current status | Used for | Rule |
+| --- | --- | --- | --- |
+| [GitHub issue 12](https://github.com/dapi/memory-bank/issues/12) | open | Adjacent owner for compact task-flow, bugfix-flow, refactor-flow and task templates | It is a dependency/context marker only; not a finalized local design artifact for FT-013. |
+| [GitHub issue 13](https://github.com/dapi/memory-bank/issues/13) | open | Source task and acceptance criteria | Scope and acceptance in `brief.md` are derived from issue 13. |
+
+## Traceability
+
+| Requirement ID | Solution refs | Contracts / invariants | Failure / rollout refs |
+| --- | --- | --- | --- |
+| `REQ-01` | `SOL-01`, `TRD-01`, `C4-00`, `SD-01` | `CTR-01`, `INV-01` | `FM-02`, `RB-01`, `RB-02` |
+| `REQ-02` | `SOL-02`, `TRD-02`, `SD-02` | `CTR-01`, `CTR-04`, `INV-02` | `FM-02`, `RB-02` |
+| `REQ-03` | `SOL-03`, `TRD-03`, `SD-03`, `SD-04` | `CTR-01`, `CTR-04`, `INV-03` | `FM-01`, `FM-03`, `RB-01` |
+| `REQ-04` | `SOL-04`, `SOL-05` | `CTR-02`, `CTR-03`, `INV-01` | `FM-01`, `RB-01` |
+| `REQ-05` | `SOL-06`, `ALT-03`, `ALT-04`, `SD-03` | `INV-03`, `INV-04` | `FM-01`, `FM-03` |
+| `REQ-06` | `ALT-01`, `TRD-02`, `SD-04` | `CTR-04` | `FM-02`, `RB-02` |

--- a/memory-bank/features/FT-013/implementation-plan.md
+++ b/memory-bank/features/FT-013/implementation-plan.md
@@ -1,0 +1,144 @@
+---
+title: "FT-013: Implementation Plan"
+doc_kind: feature
+doc_function: derived
+purpose: "Execution-план реализации issue 13. Фиксирует discovery context, шаги, риски и test strategy без переопределения canonical problem и solution facts."
+derived_from:
+  - brief.md
+  - design.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_013_scope
+  - ft_013_selected_design
+  - ft_013_acceptance_criteria
+  - ft_013_blocker_state
+---
+# FT-013: Implementation Plan
+
+## Цель текущего плана
+
+Реализовать issue 13 в generic memory-bank template: добавить optional workflow decision log, workflow metrics и workflow routing developer brief, обновить routing navigation, проверить link integrity и отсутствие source project leakage.
+
+## Grounding / Support References
+
+| Document | Role in this plan | Facts reused | Conflict action |
+| --- | --- | --- | --- |
+| `brief.md` | canonical problem / verify owner | `REQ-*`, `NS-*`, `ASM-*`, `CON-*`, `SC-*`, `CHK-*`, `EVID-*` | Update `brief.md` first |
+| `design.md` | solution owner | `SOL-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` | Update `design.md` first |
+| `decision-log.md` | decision provenance | `DL-FT013-*` FPF decisions | Update `decision-log.md` and then owner docs |
+| `../../flows/workflows.md` | current routing owner | Existing workflow types and routing rules | Update only routing pointers in FT-013 scope |
+| `../../flows/README.md` | flows navigation owner | Existing annotated index style | Add optional docs with annotations |
+| [GitHub issue 12](https://github.com/dapi/memory-bank/issues/12) | adjacent planned task-flow owner | Task-flow dependency and non-scope boundary | Do not implement issue 12 in FT-013 |
+| Source docs from `alfagen/mercury` | pattern evidence | Decision log / metrics / developer brief structures | Genericize; do not copy project-specific facts |
+
+## Current State / Reference Points
+
+| Path / module | Current role | Why relevant | Reuse / mirror |
+| --- | --- | --- | --- |
+| `memory-bank/flows/workflows.md` | Canonical routing overview | FT-013 adds optional selector rationale/metrics/brief around this doc | Reuse concise routing language and autonomy gradient |
+| `memory-bank/flows/README.md` | Index for reusable flow docs | Acceptance requires optional docs reachable from flows README | Add annotated links matching existing style |
+| `memory-bank/flows/feature-flow.md` | Feature lifecycle owner | Governs this package and boundary between brief/design/plan | Keep unchanged |
+| `memory-bank/flows/epic-flow.md` | Existing decision-log pattern at epic level | Shows local decision log concept and evidence-backed decision language | Mirror decision provenance style, not epic scope |
+| `memory-bank/engineering/testing-policy.md` | Test/evidence policy | Defines automated checks/manual-only expectations | Use lightweight doc checks as deterministic verification |
+| `scripts/check_memory_bank_index.py` | Link/index audit | Primary automated validation for new markdown docs | Run as `CHK-01` |
+| `memory-bank/flows/templates/README.md` | Templates index | Relevant only if implementation adds files under `flows/templates/` | Do not update unless design changes |
+
+## Test Strategy
+
+| Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites / commands | Required CI suites / jobs | Manual-only gap / justification | Manual-only approval ref |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Markdown navigation and frontmatter dependencies | `REQ-01`..`REQ-05`, `CHK-01` | `scripts/check_memory_bank_index.py` audits links, reachability and expected README indices | Run existing script after docs and index updates | `python3 scripts/check_memory_bank_index.py` | Same script if CI runs repository checks | none | none |
+| Whitespace / conflict markers | `REQ-06`, `CHK-02` | Git has built-in diff check | Run diff check before handoff | `git diff --check` | Same command if CI configured | none | none |
+| Generic source leakage | `REQ-06`, `CHK-03` | No dedicated script | Run targeted `rg` scan against delivered workflow docs | `rg -n "Mercury|alfagen|2026-06-29|2026-07-28|2026-07-29|dip|Rails|Rake|RSpec|MySQL" memory-bank/flows/workflow-*.md` | none unless added later | Manual judgment still needed for subtle project-specific prose | none |
+| Acceptance traceability | `REQ-01`..`REQ-06`, `CHK-04` | Manual review by implementer/reviewer | Prepare PR/body note or review note mapping issue 13 acceptance to docs | Manual review procedure from `brief.md` | Reviewer approval / PR review | Manual by nature because it checks semantic fit | none |
+
+## Open Questions / Ambiguities
+
+No unresolved questions block execution. The task-flow dependency, design-required decision and decision-log ownership correction are closed in [decision-log.md](decision-log.md).
+
+## Environment Contract
+
+| Area | Contract | Used by | Failure symptom |
+| --- | --- | --- | --- |
+| setup | Repository checkout with current branch and Python 3 | `STEP-01`..`STEP-06` | `scripts/check_memory_bank_index.py` cannot run |
+| test | Lightweight repository checks from `brief.md` are authoritative for this docs-only feature | `STEP-05`, `STEP-06` | Link audit, diff check or leak scan fails |
+| access / network / secrets | GitHub issue/source reading was needed for planning; implementation itself should not require secrets or live external systems | `STEP-01` | Missing source access should not block because selected design is already captured |
+
+## Preconditions
+
+| Precondition ID | Canonical ref | Required state | Used by steps | Blocks start |
+| --- | --- | --- | --- | --- |
+| `PRE-01` | `brief.md` Design Requirement Decision | `Design required: yes` and `brief.md` active | `STEP-01`..`STEP-06` | yes |
+| `PRE-02` | `design.md` `C4-00`, `SOL-*`, `SD-*` | `design.md` active and no required C4 artifact | `STEP-01`..`STEP-06` | yes |
+| `PRE-03` | `SD-03`, `INV-03` | Issue 12 remains outside implementation scope; no links to absent local task-flow docs | `STEP-02`, `STEP-03`, `STEP-04` | yes |
+
+## Workstreams
+
+| Workstream | Implements | Result | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| `WS-1` | `REQ-01`, `SOL-01` | `workflow-decision-log.md` added | agent | `PRE-01`, `PRE-02` |
+| `WS-2` | `REQ-02`, `SOL-02` | `workflow-metrics.md` added | agent | `PRE-01`, `PRE-02` |
+| `WS-3` | `REQ-03`, `SOL-03` | `workflow-routing-developer-brief.md` added | agent | `PRE-01`, `PRE-02`, `PRE-03` |
+| `WS-4` | `REQ-04`, `SOL-04`, `SOL-05` | `flows/README.md` and `workflows.md` updated | agent | `WS-1`, `WS-2`, `WS-3` |
+| `WS-5` | `REQ-06`, `CHK-01`..`CHK-04` | Verification outputs and review notes ready | agent / reviewer | `WS-1`..`WS-4` |
+
+## Approval Gates
+
+No risky, irreversible, costly or external-effect action is planned for implementation. Human review is still expected before merge through normal PR review.
+
+## Порядок работ
+
+| Step ID | Actor | Implements | Goal | Touchpoints | Artifact | Verifies | Evidence IDs | Check command / procedure | Blocked by | Needs approval | Escalate if |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `STEP-01` | agent | `REQ-01`, `SOL-01` | Add generic workflow decision log | `memory-bank/flows/workflow-decision-log.md` | New governed markdown doc | `CHK-01`, `CHK-03`, `CHK-04` | `EVID-01`, `EVID-03`, `EVID-04` | Review frontmatter, links, genericity | `PRE-01`, `PRE-02` | none | Decision log needs source-specific facts to make sense |
+| `STEP-02` | agent | `REQ-02`, `SOL-02`, `SD-02` | Add workflow metrics template | `memory-bank/flows/workflow-metrics.md` | New governed markdown doc | `CHK-01`, `CHK-03`, `CHK-04` | `EVID-01`, `EVID-03`, `EVID-04` | Review safety-first decision rule and metric cards | `PRE-01`, `PRE-02` | none | Speed can be read as overriding safety |
+| `STEP-03` | agent | `REQ-03`, `SOL-03`, `SD-03`, `SD-04` | Add developer brief | `memory-bank/flows/workflow-routing-developer-brief.md` | New guide/template doc | `CHK-01`, `CHK-03`, `CHK-04` | `EVID-01`, `EVID-03`, `EVID-04` | Review no links to absent task-flow docs | `PRE-03` | none | Brief requires issue 12 artifacts to be truthful |
+| `STEP-04` | agent | `REQ-04`, `SOL-04`, `SOL-05` | Make optional docs reachable | `memory-bank/flows/README.md`, `memory-bank/flows/workflows.md` | Updated navigation/routing text | `CHK-01`, `CHK-04` | `EVID-01`, `EVID-04` | Run index audit | `WS-1`, `WS-2`, `WS-3` | none | Link audit points to absent docs |
+| `STEP-05` | agent | `REQ-06` | Run deterministic checks | repo root | Command outputs | `CHK-01`, `CHK-02`, `CHK-03` | `EVID-01`, `EVID-02`, `EVID-03` | Commands from `brief.md` checks | `STEP-01`..`STEP-04` | none | Any required check fails |
+| `STEP-06` | agent / reviewer | `REQ-01`..`REQ-06` | Final semantic acceptance review | New/changed docs | Review note / PR body | `CHK-04` | `EVID-04` | Map issue 13 acceptance to changed docs | `STEP-05` | none | Scope drift into issue 12 is found |
+
+## Parallelizable Work
+
+- `PAR-01` `WS-1`, `WS-2` and `WS-3` can be drafted independently after `design.md` is active.
+- `PAR-02` `WS-4` must wait for the new docs to exist to avoid broken navigation links.
+- `PAR-03` Verification in `WS-5` must run after all docs/navigation updates.
+
+## Checkpoints
+
+| Checkpoint ID | Refs | Condition | Evidence IDs |
+| --- | --- | --- | --- |
+| `CP-01` | `STEP-01`, `STEP-02`, `STEP-03`, `CTR-01` | All new workflow docs exist with valid frontmatter and generic wording | `EVID-04` |
+| `CP-02` | `STEP-04`, `CTR-02`, `CTR-03` | Flows navigation reaches optional docs without absent task-flow links | `EVID-01` |
+| `CP-03` | `STEP-05`, `CHK-01`, `CHK-02`, `CHK-03` | Required local checks pass | `EVID-01`, `EVID-02`, `EVID-03` |
+
+## Execution Risks
+
+| Risk ID | Risk | Impact | Mitigation | Trigger |
+| --- | --- | --- | --- | --- |
+| `ER-01` | Over-copying source docs | Generic template gets source-specific dates/names/commands | Use `CTR-04` and `CHK-03`; write placeholders and generic decision windows | `CHK-03` matches or review finds source-specific prose |
+| `ER-02` | Accidental scope expansion into issue 12 | FT-013 becomes too large and conflicts with planned task-flow feature | Keep `NS-01`, `SD-03`, `INV-03`; avoid local links to absent docs | Implementation starts creating task-flow/task templates |
+| `ER-03` | Metrics look precise but are not adaptable | Downstream projects treat example thresholds/dates as universal | Mark windows/targets as project-adapted fields, not fixed defaults | Metrics doc includes hard-coded pilot dates |
+
+## Stop Conditions / Fallback
+
+| Stop ID | Related refs | Trigger | Immediate action | Safe fallback state |
+| --- | --- | --- | --- | --- |
+| `STOP-01` | `SD-03`, `FM-01` | Implementation requires local task-flow docs to avoid misleading readers | Stop and raise human gate or wait for issue 12 | FT-013 docs remain planned; no speculative broken links |
+| `STOP-02` | `CTR-04`, `FM-02` | Source-specific content cannot be safely generalized | Stop and ask for human decision on acceptable generic wording | New workflow docs not merged |
+| `STOP-03` | `CHK-01` | Link audit fails for reasons outside FT-013 scope | Fix local FT-013 links if possible; otherwise escalate | Changes remain unshipped |
+
+## Plan-local Evidence
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checkpoints |
+| --- | --- | --- | --- | --- |
+| `EVID-09` | Review-improve report for feature-doc package | implementer | `decision-log.md` entries and final response summary | `CP-01`, `CP-02` |
+
+## Готово для приемки
+
+- All workstreams are complete or explicitly stopped through `STOP-*`.
+- `workflow-decision-log.md`, `workflow-metrics.md` and `workflow-routing-developer-brief.md` exist and are reachable.
+- Required local checks from `brief.md` pass.
+- Generic leak scan has no matches in delivered workflow docs.
+- Manual acceptance review maps issue 13 acceptance to changed docs.
+- Any future task-flow links are left to issue 12 or a follow-up after issue 12 lands.

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -29,3 +29,8 @@ audience: humans_and_agents
 - Базовый формат: `FT-XXX/`
 - Вместо `XXX` используй идентификатор, принятый в проекте: issue id, ticket id или другой стабильный ключ
 - Один package = одна delivery-единица
+
+## Packages
+
+- [FT-013](FT-013/)
+  Читать, когда нужно: открыть feature package для issue 13 про generic workflow routing metrics, decision log и developer brief.

--- a/memory-bank/flows/README.md
+++ b/memory-bank/flows/README.md
@@ -8,6 +8,9 @@ derived_from:
   - epic-flow.md
   - feature-flow.md
   - workflows.md
+  - workflow-decision-log.md
+  - workflow-metrics.md
+  - workflow-routing-developer-brief.md
   - templates/README.md
 status: active
 audience: humans_and_agents
@@ -18,6 +21,9 @@ audience: humans_and_agents
 Каталог `memory-bank/flows/` содержит reusable process-layer для шаблона: lifecycle rules, taxonomy стабильных идентификаторов и governed templates.
 
 - [Task Workflows](workflows.md) — маршрутизация задач по типам, базовый цикл разработки и градиент автономии.
+- [Workflow Decision Log](workflow-decision-log.md) — optional журнал причин и ожидаемых последствий изменений workflow selector-а и profiles.
+- [Workflow Metrics](workflow-metrics.md) — optional safety-first метрики для проверки workflow profiles без подмены evidence скоростью.
+- [Workflow Routing Developer Brief](workflow-routing-developer-brief.md) — короткий reusable brief для выбора workflow profile и promotion triggers.
 - [Epic Flow](epic-flow.md) — lifecycle крупных инициатив, roadmap, decision log, risks и handoff в feature packages.
 - [Feature Flow](feature-flow.md) — lifecycle `brief.md -> optional design.md -> implementation-plan.md`, gates и стабильные ID (`REQ-*`, `SOL-*`, `STEP-*`).
 - [Templates Index](templates/README.md) — эталонные шаблоны governed-документов, включая PRD, use case, epic, feature и ADR.

--- a/memory-bank/flows/workflow-decision-log.md
+++ b/memory-bank/flows/workflow-decision-log.md
@@ -1,0 +1,109 @@
+---
+title: Workflow Decision Log
+doc_kind: governance
+doc_function: canonical
+purpose: "Фиксирует причины, решения и expected consequences изменений workflow selector-а и workflow profiles."
+derived_from:
+  - ../dna/governance.md
+  - workflows.md
+status: active
+audience: humans_and_agents
+canonical_for:
+  - workflow_decision_rationale
+  - workflow_change_causal_trace
+  - workflow_profile_review_rules
+---
+# Workflow Decision Log
+
+Этот документ является optional process-layer owner-ом для решений о workflow selector-е. Используй его, когда проект меняет правила выбора workflow profile, вводит compact profile, ужесточает promotion triggers или пересматривает documentation ceremony.
+
+Decision log не заменяет [workflows.md](workflows.md): canonical routing rules остаются там. Здесь живет причинно-следственная запись: почему selector менялся, какие риски учитывались, как решение будет пересмотрено и какими evidence оно должно подтверждаться.
+
+## When To Use
+
+Создавай или обновляй запись `DL-WF-*`, если изменение:
+
+- добавляет, удаляет или переименовывает workflow profile;
+- меняет promotion triggers между compact, managed, feature и epic profiles;
+- снижает или повышает required documentation/evidence для класса задач;
+- меняет routing signature fields или их interpretation;
+- меняет safety/evidence gates для выбора workflow;
+- вводит pilot/evaluation period для workflow selector-а.
+
+Не используй этот документ для feature-local design decisions, ADR-level architecture decisions или PR-specific implementation choices.
+
+## Decision Entry Template
+
+```markdown
+## DL-WF-XXX: Short decision name
+
+**Status:** proposed / accepted / superseded / rejected
+
+**Date:** YYYY-MM-DD
+
+**Context:** What observed problem or opportunity makes the workflow change necessary.
+
+**Evidence:** Which carriers support the claim: issues, PR reviews, review reports, metrics, incident notes or downstream feedback.
+
+**Decision:** What changes in the selector, profiles, routing signature, gates or documentation requirements.
+
+**Expected consequences:**
+
+1. What should improve.
+2. What safety/evidence risk is being controlled.
+3. What would show the decision is wrong.
+
+**Review rule:** When and how the decision is revisited. Link to [workflow-metrics.md](workflow-metrics.md) if measured.
+
+**Non-goals:** What this decision deliberately does not change.
+
+**Follow-ups:** Optional issue/PR links for implementation or later tightening.
+```
+
+## Required Fields
+
+| Field | Required | Rule |
+| --- | --- | --- |
+| Status | yes | Use `proposed`, `accepted`, `superseded` or `rejected`. |
+| Date | yes | Use the decision date, not the measurement window. |
+| Context | yes | State the workflow problem without hiding it inside the decision. |
+| Evidence | yes | Name concrete carriers or explicitly mark evidence as qualitative. |
+| Decision | yes | State the selector/profile change in reviewable terms. |
+| Expected consequences | yes | Include both expected benefit and safety/evidence risk. |
+| Review rule | yes | Explain when the decision is revisited and what evidence is used. |
+| Non-goals | recommended | Prevent scope creep into unrelated flows. |
+| Follow-ups | optional | Link implementation issues or later audits. |
+
+## Review Rules
+
+- Safety and evidence regressions override ceremony or lead-time gains.
+- A compact profile is not successful if it increases safety misroutes, missing evidence or rework from wrong routing.
+- If workflow metrics are inconclusive, keep the decision in `proposed` or extend the review window instead of silently promoting it.
+- If a selector change affects feature/epic lifecycle gates, update the canonical owner documents before treating the decision as accepted.
+- If a decision depends on a document that does not exist yet, record it as a follow-up dependency rather than linking to a missing local file.
+
+## Example Entry
+
+```markdown
+## DL-WF-001: Add compact profile evaluation
+
+**Status:** proposed
+
+**Date:** YYYY-MM-DD
+
+**Context:** Small low-risk tasks are receiving heavyweight documentation, but the project still needs evidence that a smaller profile will not hide risky work.
+
+**Evidence:** Review findings and PR notes from the selected baseline window.
+
+**Decision:** Pilot a compact profile for low-risk tasks with explicit promotion triggers for contract change, high risk, missing evidence or design uncertainty.
+
+**Expected consequences:**
+
+1. Less ceremony for small tasks.
+2. No increase in safety misroutes or missing evidence.
+3. Profile is tightened if review comments show repeated missing context.
+
+**Review rule:** Evaluate the pilot with [workflow-metrics.md](workflow-metrics.md) after the configured pilot window.
+
+**Non-goals:** Do not change feature-flow or epic-flow lifecycle gates.
+```

--- a/memory-bank/flows/workflow-metrics.md
+++ b/memory-bank/flows/workflow-metrics.md
@@ -1,0 +1,106 @@
+---
+title: Workflow Metrics
+doc_kind: governance
+doc_function: canonical
+purpose: "Определяет safety-first метрики для проверки workflow selector-а и workflow profiles."
+derived_from:
+  - ../dna/governance.md
+  - workflows.md
+  - workflow-decision-log.md
+status: active
+audience: humans_and_agents
+canonical_for:
+  - workflow_profile_metrics
+  - workflow_profile_success_criteria
+  - workflow_measurement_windows
+---
+# Workflow Metrics
+
+Этот документ задает optional metrics template для проверки workflow selector-а. Он нужен, когда команда вводит или меняет workflow profiles и хочет проверить, стало ли меньше лишней documentation ceremony без потери safety, evidence и traceability.
+
+Метрики образуют bundle: один быстрый показатель не доказывает успех. Safety/evidence metrics всегда проверяются раньше speed metrics.
+
+## Evaluation Window Template
+
+| Window ID | Dates / source | Purpose | Included work |
+| --- | --- | --- | --- |
+| `BASELINE-01` | `<baseline window>` | Сравнить с периодом до изменения selector-а | Closed issues / merged PRs / accepted task packages |
+| `PILOT-01` | `<pilot window>` | Проверить новые или измененные workflow profiles | Closed issues / merged PRs / accepted task packages |
+| `REVIEW-01` | `<review date or review event>` | Принять решение: keep, tighten, extend, rollback | Metrics report plus qualitative review |
+
+If a PR or task is still open at the end of a window, count it only in qualitative review unless the project defines another rule.
+
+## Metric Cards
+
+| Metric ID | Characteristic | Scale / Unit | Formula | Suggested target | Evidence source |
+| --- | --- | --- | --- | --- | --- |
+| `WFM-01` | Routing coverage | Ratio, `%` | Work items with explicit routing signature or selected workflow profile / eligible work items | Project-defined threshold, commonly high enough to audit routing habits | Issue/PR body, labels, comments, task/feature docs |
+| `WFM-02` | Feature overuse rate | Ratio, `%` | Non-feature tasks that created full feature package without promotion trigger / non-feature tasks | Lower than baseline without safety regression | Issue/PR labels, docs created, routing notes |
+| `WFM-03` | Safety misroute count | Count | High-risk or contract-changing work delivered through a profile too small for its risk | `0` for the review window | PR diff review, review comments, incident notes, docs |
+| `WFM-04` | Missing-evidence review burden | Count per N PRs/tasks | Review findings asking for missing repro, verification, rollout/backout or evidence because selected profile was too small | Project-defined maximum; should not increase vs baseline | PR review comments, review reports, task docs |
+| `WFM-05` | Regression / verification coverage | Ratio, `%` | Work items with required automated coverage or approved manual-only exception / work items requiring verification | Project-defined threshold; stricter for critical domains | PR diff, test reports, evidence notes |
+| `WFM-06` | Rework from wrong profile | Ratio, `%` | Work items requiring profile promotion after review / work items with routing signature | Low and not worse than baseline | PR timeline, issue comments, package history |
+| `WFM-07` | Durable traceability for managed work | Ratio, `%` | Managed task/feature/epic work with links from issue/PR to owner docs / all managed work | High enough that owner docs are findable during review | Issue/PR links, memory-bank package indexes |
+| `WFM-08` | Small-task lead time | Duration | Median ready-to-PR or ready-to-merge duration for compact profiles | Secondary observation only; no success if safety gates fail | Issue/PR timestamps or project tracker |
+
+## Decision Rule
+
+Evaluate in this order:
+
+1. If `WFM-03 > 0`, compact or reduced-documentation profiles are unsafe for the observed window. Tighten selector or promotion triggers before claiming success.
+2. If required verification coverage in `WFM-05` misses the project-defined threshold for critical work, tighten the relevant profile even if speed improved.
+3. If `WFM-04` or `WFM-06` gets worse materially, the profile likely hides context or evidence; update workflow docs/templates before expanding use.
+4. If `WFM-01` and `WFM-07` are too low, the selector may be correct in prose but not adopted; improve prompts, PR templates or developer brief.
+5. Only after safety/evidence/traceability gates are acceptable, use `WFM-02` and `WFM-08` to judge whether ceremony decreased.
+6. If lead time improves while safety/evidence/rework worsens, the selector change is not successful.
+
+## Measurement Notes
+
+- A `workflow_profile` may be captured in an issue field, PR body, label, task package, feature package or explicit agent comment.
+- Baseline classification may be best-effort, but the method must be stated.
+- Manual-only verification counts only when it has a reason, procedure and approval/evidence reference.
+- Do not average unrelated risk classes into one score. Report critical/high-risk work separately when possible.
+- If thresholds are not known yet, mark them as project-adapted fields and run a qualitative review before setting targets.
+
+## Review Output Template
+
+```markdown
+# Workflow Metrics Review
+
+## Window
+
+- Baseline: `<baseline window>`
+- Pilot: `<pilot window>`
+- Review: `<review event>`
+
+## Safety Gates
+
+| Metric | Result | Verdict | Notes |
+| --- | --- | --- | --- |
+| `WFM-03` |  | pass/fail |  |
+| `WFM-04` |  | pass/fail |  |
+| `WFM-05` |  | pass/fail |  |
+| `WFM-06` |  | pass/fail |  |
+
+## Adoption / Traceability
+
+| Metric | Result | Verdict | Notes |
+| --- | --- | --- | --- |
+| `WFM-01` |  | pass/fail |  |
+| `WFM-07` |  | pass/fail |  |
+
+## Ceremony / Speed
+
+| Metric | Result | Verdict | Notes |
+| --- | --- | --- | --- |
+| `WFM-02` |  | observation |  |
+| `WFM-08` |  | observation |  |
+
+## Decision
+
+`keep` / `tighten` / `extend pilot` / `rollback`
+
+## Follow-ups
+
+- `FOLLOW-UP-01` ...
+```

--- a/memory-bank/flows/workflow-routing-developer-brief.md
+++ b/memory-bank/flows/workflow-routing-developer-brief.md
@@ -1,0 +1,101 @@
+---
+title: Workflow Routing Developer Brief
+doc_kind: guide
+doc_function: review_brief
+purpose: "Краткое reusable объяснение для разработчиков и агентов: как выбирать workflow profile и когда повышать задачу до более строгого flow."
+derived_from:
+  - ../dna/governance.md
+  - workflows.md
+  - workflow-decision-log.md
+  - workflow-metrics.md
+status: active
+audience: humans_and_agents
+---
+# Workflow Routing Developer Brief
+
+Этот brief можно адаптировать для команды или вставлять в issue/PR instructions. Canonical routing rules остаются в [workflows.md](workflows.md); [workflow-decision-log.md](workflow-decision-log.md) объясняет причины changes to selector, а [workflow-metrics.md](workflow-metrics.md) помогает проверить, что profiles не ухудшили safety/evidence.
+
+## Короткое правило
+
+Выбирай минимальный workflow profile, который не теряет контроль над риском, evidence и traceability.
+
+- Если работа меняет capability или user/operator/system behavior, используй feature-level flow.
+- Если работа меняет contract, rollout, security boundary, data shape, integration или requires approval, повышай profile.
+- Если работа маленькая, low-risk и не требует durable owner-docs, достаточно compact carrier в issue/PR.
+- Если compact carrier становится тесным, повышай до managed package или feature package, а не прячь complexity в prose.
+
+## Routing Signature
+
+Перед стартом зафиксируй короткую routing signature.
+
+| Field | Values / examples | Why it matters |
+| --- | --- | --- |
+| `kind` | feature / bugfix / refactor / chore / incident / docs | Determines the closest workflow family. |
+| `size` | tiny / small / medium / large | Helps avoid heavyweight docs for small safe work. |
+| `risk` | low / medium / high / critical | High risk requires stronger gates and evidence. |
+| `change_surface` | docs / tests / code / API / schema / infra / operations | Larger or external surfaces need stronger review. |
+| `contract_change` | none / internal / external / unknown | Contract changes usually require promotion. |
+| `design_need` | no / yes / unknown | Design uncertainty should not be solved inside execution steps. |
+| `evidence_need` | standard / regression / rollout / approval / unknown | Evidence need drives docs and checks. |
+
+If `risk`, `contract_change`, `design_need` or `evidence_need` is `unknown`, do discovery or choose a stricter profile.
+
+## Profile Guide
+
+| Situation | Recommended profile | Carrier / owner |
+| --- | --- | --- |
+| Tiny or small low-risk change with clear evidence | Compact issue/PR carrier | Issue/PR body, comments or checklist |
+| Local bugfix with reproducible symptom and clear root cause | Bugfix-oriented compact or managed profile | Issue/PR carrier or project-defined task package |
+| Refactor/chore with no behavior change | Refactor-oriented compact or managed profile | Issue/PR carrier or project-defined task package |
+| Work needs checkpoints, durable context or several review passes, but is not a feature | Managed task profile | Project-defined task package |
+| New or materially changed capability, contract/risk trigger, design reasoning or acceptance traceability | Feature package | `memory-bank/features/FT-XXX/` following [feature-flow.md](feature-flow.md) |
+| Multiple independent delivery units, roadmap, risk register or subissues | Epic package | `memory-bank/epics/EP-XXX/` following [epic-flow.md](epic-flow.md) |
+
+This generic template does not require a local task-flow document to exist. If a project adds one later, link the project-specific task profile docs from this brief.
+
+## Promotion Triggers
+
+Promote to a stricter profile when any trigger is true:
+
+- observable behavior changes beyond the original routing signature;
+- API, schema, event, CLI, file format, config, security, financial, data or integration contract changes;
+- rollout/backout, approval, migration or operational coordination is needed;
+- implementation requires alternatives/trade-off reasoning;
+- evidence cannot be captured in the selected carrier without losing traceability;
+- review finds missing scope, missing evidence or repeated ambiguity;
+- one task becomes several delivery units.
+
+## What Reviewers Check
+
+- Routing signature exists before implementation.
+- Selected profile matches risk and contract triggers.
+- Compact profile includes enough evidence for the changed behavior.
+- Managed/feature/epic work links from issue/PR to owner docs.
+- Feature work is not hidden inside a compact or task carrier.
+- Speed improvement is not treated as success if safety/evidence worsened.
+
+## Starter Comment Template
+
+```markdown
+## Workflow Routing
+
+| Field | Value |
+| --- | --- |
+| kind |  |
+| size |  |
+| risk |  |
+| change_surface |  |
+| contract_change |  |
+| design_need |  |
+| evidence_need |  |
+
+Selected profile:
+
+Rationale:
+
+Promotion triggers checked:
+
+Required carrier/docs:
+
+Verification/evidence:
+```

--- a/memory-bank/flows/workflows.md
+++ b/memory-bank/flows/workflows.md
@@ -97,3 +97,11 @@ Flow:
 - Если задача маленькая и понятная, не раздувай её до большого feature package.
 - Если задача меняет контракт, rollout или требует approvals, поднимай её до feature flow.
 - Если замечания не уменьшаются от итерации к итерации, проблема может быть upstream, а не в коде.
+
+## Optional Routing Support
+
+Для изменений самого selector-а используй [Workflow Decision Log](workflow-decision-log.md): он фиксирует причину, evidence, решение, expected consequences и review rule.
+
+Для проверки, что compact или managed profiles уменьшили лишнюю ceremony без потери safety/evidence, используй [Workflow Metrics](workflow-metrics.md). Safety misroutes, missing evidence и rework проверяются раньше lead time.
+
+Для короткого объяснения выбора workflow profile в issue/PR используй [Workflow Routing Developer Brief](workflow-routing-developer-brief.md). Он не заменяет этот canonical routing document и не делает optional profiles обязательными для каждого проекта.


### PR DESCRIPTION
## Summary

- Add optional workflow decision log, workflow metrics, and developer routing brief under `memory-bank/flows/`.
- Add FT-013 feature package for issue #13 and register it in the feature index.
- Link the optional workflow docs from `flows/README.md` and add routing support pointers in `flows/workflows.md`.

## Scope Notes

- Keeps issue #12 task-flow artifacts out of scope; the new docs avoid links to absent local `task-flow.md`, `bugfix-flow.md`, and `refactor-flow.md`.
- Metrics evaluate safety/evidence/rework/traceability before speed.
- Source-specific project names, pilot dates, and operational commands are not copied into reusable workflow docs.

## Checks

- `rg --files memory-bank`
- `python3 scripts/check_memory_bank_index.py`
- `git diff --check`
- `git diff --cached --check`
- `rg -n "Mercury|alfagen|2026-06-29|2026-07-28|2026-07-29|dip|Rails|Rake|RSpec|MySQL" memory-bank/flows/workflow-*.md`
- `rg -n "task-flow\.md|bugfix-flow\.md|refactor-flow\.md|\]\([^)]*(task-flow|bugfix-flow|refactor-flow)" memory-bank/flows/workflow-*.md memory-bank/flows/README.md memory-bank/flows/workflows.md`

Closes #13

Related: #12