### PR TITLE
[codex] docs: add privacy source boundary template

### DIFF
--- a/memory-bank/features/FT-016/README.md
+++ b/memory-bank/features/FT-016/README.md
@@ -1,0 +1,35 @@
+---
+title: "FT-016: Privacy / Source Boundary Support Template"
+doc_kind: feature
+doc_function: index
+purpose: "Навигация по feature package для issue 16. Читать, чтобы перейти к canonical brief, design, implementation plan и feature-local decision log."
+derived_from:
+  - ../../dna/governance.md
+  - brief.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-016: Privacy / Source Boundary Support Template
+
+## О разделе
+
+Каталог feature package начинается с canonical `brief.md`. Downstream solution/execution routes добавлены после фиксации `Design required: yes` и готовности `design.md`.
+
+## Аннотированный индекс
+
+- [brief.md](brief.md)
+  Читать, когда нужно: открыть canonical problem space, scope, non-scope и verify contract для issue 16.
+  Отвечает на вопрос: зачем нужен generic privacy/source-boundary support template и как проверить feature.
+
+- [design.md](design.md)
+  Читать, когда нужно: проверить selected solution, owner boundaries, local decisions и routing для нового support template.
+  Отвечает на вопрос: как добавить template без переноса downstream-specific деталей и без подмены `brief.md` / `design.md` / `implementation-plan.md`.
+
+- [implementation-plan.md](implementation-plan.md)
+  Читать, когда нужно: выполнить feature по шагам и проверить touched template/index surfaces.
+  Отвечает на вопрос: какие файлы менять, какие проверки запускать и какие evidence собрать.
+
+- [decision-log.md](decision-log.md)
+  Читать, когда нужно: увидеть feature-local FPF decisions, принятые при review-improve циклах.
+  Отвечает на вопрос: какие вопросы были закрыты фактами из issue/source docs и какие последствия у решений.

--- a/memory-bank/features/FT-016/brief.md
+++ b/memory-bank/features/FT-016/brief.md
@@ -1,0 +1,128 @@
+---
+title: "FT-016: Privacy / Source Boundary Support Template"
+doc_kind: feature
+doc_function: canonical
+purpose: "Canonical brief для issue 16. Фиксирует problem space, scope, non-scope и verify contract для generic privacy/source-boundary support template."
+derived_from:
+  - ../../flows/feature-flow.md
+  - https://github.com/dapi/memory-bank/issues/16
+status: active
+delivery_status: done
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - solution_space
+---
+
+# FT-016: Privacy / Source Boundary Support Template
+
+## What
+
+### Problem
+
+AI/agent tooling, observability, logs, transcripts и external metadata могут содержать приватные данные. Сейчас feature support templates не дают generic места, где feature package явно фиксирует, какие source classes можно читать, хранить и цитировать, какие source classes исключены, какой confidence/status у источников и кто владеет boundary facts.
+
+Issue 16 указывает downstream source patterns из `dapi/zelma`, но требует не переносить `zelma`, Codex session internals или конкретные runtime details обратно в template.
+
+### Outcome
+
+| Metric ID | Metric | Baseline | Target | Measurement method |
+| --- | --- | --- | --- | --- |
+| `MET-01` | Generic privacy/source-boundary support coverage | В `flows/templates/feature/support/` нет dedicated template для privacy/source boundaries | Есть generic support template с allowed metadata, explicitly excluded data, source inventory confidence/status, test evidence и owner boundaries | Review changed template docs against `REQ-*`, `SC-*`, `CHK-*` |
+| `MET-02` | Template boundary clarity | Existing support docs declare non-ownership individually, but privacy/source-boundary support is absent | New support doc explicitly states it does not replace `brief.md`, `design.md` or `implementation-plan.md` | Traceability and content review of support template plus routing docs |
+
+### Scope
+
+- `REQ-01` Add a generic feature-support template for privacy/source-boundary documentation under `memory-bank/flows/templates/feature/support/`.
+- `REQ-02` The template must cover allowed metadata, explicitly excluded data, confidence/status for sources, source inventory, test evidence, and owner boundaries.
+- `REQ-03` Update feature-flow/template routing so agents know when a privacy/source-boundary support doc is needed.
+- `REQ-04` Keep the template generic and exclude downstream-specific `zelma`, Codex session internals and concrete runtime details.
+- `REQ-05` Register the new support template in template indexes / navigation surfaces touched by the feature.
+
+### Non-Scope
+
+- `NS-01` Do not implement runtime privacy filtering, source discovery code, observability code, or tests outside documentation templates.
+- `NS-02` Do not add project-specific `zelma` behavior, Codex session internals, concrete command contracts, raw log shapes, transcript schemas or production runtime details to the generic template.
+- `NS-03` Do not turn the support doc into a global privacy policy, legal compliance policy, ADR, or canonical owner for feature requirements / selected design / execution sequencing.
+- `NS-04` Do not create a project-level use case unless implementation work later proves a stable reusable scenario beyond this template change.
+
+### Constraints / Assumptions
+
+- `ASM-01` Issue 16 is the canonical source for scope and acceptance for this feature.
+- `ASM-02` The referenced `dapi/zelma` files are source examples for abstraction only; they are not upstream owners for this generic template repository.
+- `CON-01` Feature-flow boundary rules apply: support docs may aid grounding/review/traceability but cannot own canonical problem space, solution space, acceptance inventory, or execution sequencing.
+- `CON-02` The repository has no build/runtime app; verification is documentation/index/link oriented.
+
+## Design Requirement Decision
+
+| Decision | Reason | Downstream owner |
+| --- | --- | --- |
+| `Design required: yes` | The feature changes governed template contracts and support-doc owner boundaries. Selected template shape, routing rules and local decisions must be stabilized before execution planning. | `design.md` |
+
+## Verify
+
+### Exit Criteria
+
+- `EC-01` New privacy/source-boundary support template exists in the feature support template directory and is registered in relevant template navigation.
+- `EC-02` The new template explicitly covers allowed metadata, excluded data, source inventory, confidence/status, evidence, and owner boundaries.
+- `EC-03` Feature-flow and feature/design/implementation-plan templates explain when this support doc is needed without making it canonical owner for requirements, selected design, checks, evidence contract or execution sequencing.
+- `EC-04` Generic template surfaces do not contain downstream-specific `zelma`, Codex session internals, concrete runtime details, raw transcript/log schemas, prompts or secrets.
+
+### Traceability matrix
+
+| Requirement ID | Problem refs | Acceptance refs | Checks | Evidence IDs |
+| --- | --- | --- | --- | --- |
+| `REQ-01` | `ASM-01`, `CON-01` | `EC-01`, `SC-01` | `CHK-01` | `EVID-01` |
+| `REQ-02` | `ASM-01`, `CON-01` | `EC-02`, `SC-01`, `SC-02`, `NEG-01` | `CHK-02` | `EVID-02` |
+| `REQ-03` | `CON-01` | `EC-03`, `SC-03` | `CHK-03` | `EVID-03` |
+| `REQ-04` | `ASM-02`, `NS-02` | `EC-04`, `NEG-01` | `CHK-04` | `EVID-04` |
+| `REQ-05` | `CON-02` | `EC-01` | `CHK-01`, `CHK-05` | `EVID-01`, `EVID-05` |
+
+### Acceptance Scenarios
+
+- `SC-01` An agent creating a feature that touches logs, transcripts, external metadata or source inventories can instantiate a generic privacy/source-boundary support doc from `flows/templates/feature/support/`.
+- `SC-02` The instantiated support doc gives the agent places to record allowed metadata, explicitly excluded private data, source confidence/status, evidence expectations and ownership boundaries.
+- `SC-03` An agent reading feature-flow, design template or implementation-plan template can identify when the privacy/source-boundary support doc is appropriate and where canonical facts still belong.
+
+### Negative / Edge Scenarios
+
+- `NEG-01` The generic template must not encourage reading, storing or citing private transcripts, prompts, raw logs, secrets, tool IO or downstream runtime internals without an explicit feature-owned permission / boundary.
+- `NEG-02` The support doc must not redefine `REQ-*`, selected `SOL-*`, canonical `CHK-*` / `EVID-*`, or `STEP-*`.
+
+### Checks
+
+| Check ID | Covers | How to check | Expected result | Evidence path |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `EC-01`, `REQ-01`, `REQ-05` | `rg -n "privacy-source-boundary|Privacy / Source Boundary|source-boundary" memory-bank/flows memory-bank/features/README.md` | New template and routing/index references are discoverable | `artifacts/ft-016/verify/chk-01/` |
+| `CHK-02` | `EC-02`, `REQ-02` | Review `memory-bank/flows/templates/feature/support/privacy-source-boundary.md` for required sections | Required coverage appears without canonical ownership leakage | `artifacts/ft-016/verify/chk-02/` |
+| `CHK-03` | `EC-03`, `REQ-03` | Review feature-flow plus feature `brief.md`, `design.md`, `implementation-plan.md` templates for routing and ownership wording | Routing exists and keeps owner boundaries intact | `artifacts/ft-016/verify/chk-03/` |
+| `CHK-04` | `EC-04`, `REQ-04`, `NEG-01` | `rg -n "zelma|Codex session|session_meta|zellij|\\.zelma|process_argv" memory-bank/flows/templates memory-bank/flows/feature-flow.md` | No downstream-specific source/runtime terms appear in generic template surfaces | `artifacts/ft-016/verify/chk-04/` |
+| `CHK-05` | `EC-01`, `REQ-05` | `python3 scripts/check_memory_bank_index.py && git diff --check` | Index/link audit and whitespace checks pass | `artifacts/ft-016/verify/chk-05/` |
+
+### Test matrix
+
+| Check ID | Evidence IDs | Evidence path |
+| --- | --- | --- |
+| `CHK-01` | `EVID-01` | `artifacts/ft-016/verify/chk-01/` |
+| `CHK-02` | `EVID-02` | `artifacts/ft-016/verify/chk-02/` |
+| `CHK-03` | `EVID-03` | `artifacts/ft-016/verify/chk-03/` |
+| `CHK-04` | `EVID-04` | `artifacts/ft-016/verify/chk-04/` |
+| `CHK-05` | `EVID-05` | `artifacts/ft-016/verify/chk-05/` |
+
+### Evidence
+
+- `EVID-01` Search output proving template and index/routing references exist.
+- `EVID-02` Review note or diff excerpt proving required sections exist in the new support template.
+- `EVID-03` Review note or diff excerpt proving routing/ownership updates exist in feature-flow and feature templates.
+- `EVID-04` Search output proving downstream-specific source/runtime terms are absent from generic template surfaces.
+- `EVID-05` Output from memory-bank index audit and whitespace check.
+
+### Evidence contract
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checks |
+| --- | --- | --- | --- | --- |
+| `EVID-01` | Search output | implementer | `artifacts/ft-016/verify/chk-01/` | `CHK-01` |
+| `EVID-02` | Template coverage review note | reviewer / implementer | `artifacts/ft-016/verify/chk-02/` | `CHK-02` |
+| `EVID-03` | Routing/ownership review note | reviewer / implementer | `artifacts/ft-016/verify/chk-03/` | `CHK-03` |
+| `EVID-04` | Generic-surface leakage search output | implementer | `artifacts/ft-016/verify/chk-04/` | `CHK-04` |
+| `EVID-05` | Index audit and diff check output | implementer | `artifacts/ft-016/verify/chk-05/` | `CHK-05` |

--- a/memory-bank/features/FT-016/decision-log.md
+++ b/memory-bank/features/FT-016/decision-log.md
@@ -1,0 +1,115 @@
+---
+title: "FT-016: Decision Log"
+doc_kind: feature-support
+doc_function: decision_log
+purpose: "Feature-local decision log for FPF-backed decisions made while preparing and reviewing FT-016 documents."
+derived_from:
+  - brief.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - global_architecture_policy_without_adr
+  - ft_016_scope
+  - ft_016_acceptance_criteria
+---
+
+# FT-016: Decision Log
+
+## FPF Reading Rule
+
+Record facts, assumptions, reasoning and consequences separately. Use this log only for feature-local decisions that do not require global ADR.
+
+## Relationship To Canonical Owners
+
+`decision-log.md` records reasoning for feature-local decisions. `brief.md` remains the canonical owner for scope and acceptance. `design.md` remains the canonical owner for selected solution facts.
+
+## DL-01: Design Layer Required
+
+**Date:** 2026-07-08
+
+**Question:**
+
+Does FT-016 need `design.md`, or can it proceed from `brief.md` directly to `implementation-plan.md`?
+
+**Status:** Resolved.
+
+**Facts:**
+
+- Issue 16 asks to add a generic support template and clarify when it is needed in feature/design/implementation-plan templates.
+- `feature-flow.md` requires `design.md` when a feature changes file format, governed contracts, support boundaries, or would otherwise force `implementation-plan.md` to make solution decisions.
+- FT-016 must decide selected template shape, owner boundaries and generic-vs-downstream separation before execution sequencing.
+
+**Reasoning:**
+
+FPF Strict Distinction separates problem facts, solution decisions and work occurrence. Without `design.md`, the implementation plan would have to choose the template role, naming, local IDs and ownership constraints, which would mix solution-space decisions into execution planning.
+
+**Decision:**
+
+FT-016 requires `design.md`.
+
+**Consequences:**
+
+- `brief.md` records `Design required: yes`.
+- `design.md` owns `SOL-*`, `SD-*`, contracts, invariants and failure modes.
+- `implementation-plan.md` must derive from both `brief.md` and `design.md`.
+
+## DL-02: Single Privacy / Source Boundary Support Template
+
+**Date:** 2026-07-08
+
+**Question:**
+
+Should FT-016 create one combined support template or split privacy boundary and source inventory into separate templates?
+
+**Status:** Resolved.
+
+**Facts:**
+
+- Issue 16 asks for a generic support template for "privacy/source boundary".
+- Issue acceptance requires both privacy exclusion behavior and source confidence/status.
+- The referenced downstream examples have separate privacy boundary and source inventory docs, but issue 16 does not ask to preserve that split.
+- Feature-flow support docs should be created only when they reduce real ambiguity; extra templates add lifecycle/navigation overhead.
+
+**Reasoning:**
+
+FPF Bounded Context makes the support doc boundary explicit: the relevant context is "what sources may be read/stored/cited for this feature, with what confidence and owner boundary." Privacy boundary and source inventory are two aspects of that same support context. FPF Evidence Graph also ties source inventory and evidence permissions together: a source claim needs carriers/confidence, but privacy rules constrain which carriers can be used.
+
+**Decision:**
+
+Create one support template named `privacy-source-boundary.md`.
+
+**Consequences:**
+
+- The template must keep allowed metadata, excluded data, source inventory, confidence/status and evidence rules in one artifact.
+- It must still separate privacy permission from source confidence so confidence is never treated as access authorization.
+
+## DL-03: Support Doc Function Is Reference, Not Evidence
+
+**Date:** 2026-07-08
+
+**Question:**
+
+Should instantiated privacy/source-boundary support docs default to `doc_function: evidence` or `doc_function: reference`?
+
+**Status:** Resolved.
+
+**Facts:**
+
+- Existing generic support templates use `doc_function: reference`.
+- The downstream source examples use `doc_function: evidence`, but they are project-specific artifacts.
+- Issue 16 says the support doc must not replace `brief.md` / `design.md`.
+- The new template will describe source boundaries and evidence expectations; it is not itself proof that checks passed.
+
+**Reasoning:**
+
+FPF Evidence Graph distinguishes a knowledge artifact from evidence carriers. A support doc can inventory admissible source carriers and evidence constraints, but the actual check outputs remain evidence carriers produced during verification.
+
+**Decision:**
+
+Use `doc_function: reference` for instantiated privacy/source-boundary support docs.
+
+**Consequences:**
+
+- The template may include a Test Evidence section, but it must route concrete check evidence to `brief.md` `EVID-*` or plan-local evidence.
+- The support doc stays a companion/reference artifact and not an execution evidence replacement.

--- a/memory-bank/features/FT-016/design.md
+++ b/memory-bank/features/FT-016/design.md
@@ -1,0 +1,114 @@
+---
+title: "FT-016: Design"
+doc_kind: feature
+doc_function: canonical
+purpose: "Solution-space документ для FT-016. Фиксирует selected template shape, owner boundaries, local decisions and trade-offs без переопределения problem space или execution contract."
+derived_from:
+  - brief.md
+  - decision-log.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_016_scope
+  - ft_016_acceptance_criteria
+  - ft_016_evidence_contract
+  - implementation_sequence
+---
+
+# FT-016: Design
+
+## Design Pack
+
+| Artifact | Role | Owns |
+| --- | --- | --- |
+| `design.md` | Feature-local solution owner | `SOL-*`, `ALT-*`, `TRD-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` |
+| `decision-log.md` | Feature-local FPF decision ledger | `DL-*` facts, reasoning, decisions and consequences |
+
+## Context
+
+Issue 16 asks for a generic support template that helps agents govern privacy/source access for AI/agent tooling, observability, logs, transcripts and external metadata. Existing feature support templates cover runtime surfaces, UI references and derived use cases, but none explicitly owns source inventory and privacy/source boundary evidence.
+
+The solution must abstract useful shape from referenced downstream source docs without copying downstream system details into this template repository.
+
+## C4 Applicability
+
+| C4 ID | Decision | Trigger / reason | Artifact |
+| --- | --- | --- | --- |
+| `C4-00` | `not required` | The feature changes Markdown governance templates and indexes only. It does not change runtime/deployable/container/API/storage/integration/security execution boundaries. | `none` |
+
+## Selected Solution
+
+- `SOL-01` Add `memory-bank/flows/templates/feature/support/privacy-source-boundary.md` as a governed feature-support template for source privacy and evidence boundaries.
+- `SOL-02` Update `memory-bank/flows/feature-flow.md` so the new support doc is listed with trigger conditions, ownership limits and support ID taxonomy.
+- `SOL-03` Update feature package templates (`README.md`, `brief.md`, `design.md`, `implementation-plan.md`) where routing/discovery wording must mention privacy/source-boundary support docs.
+- `SOL-04` Register the new template in `memory-bank/flows/templates/README.md` and `memory-bank/features/README.md` navigation.
+- `SOL-05` Keep all generic template surfaces free of downstream-specific source/runtime terms; downstream sources may be cited only in this feature package as issue evidence.
+
+## Alternatives Considered
+
+| Alternative ID | Option | Why not selected |
+| --- | --- | --- |
+| `ALT-01` | Fold privacy/source-boundary fields into `runtime-surfaces.md` | Rejected because issue 16 covers source permissions, source inventory confidence and privacy exclusions that are not necessarily runtime surfaces. Combining them would blur support doc roles. |
+| `ALT-02` | Put privacy/source-boundary rules directly into `brief.md` / `design.md` templates | Rejected because source inventories and evidence boundaries are support/reference facts. Canonical requirements and selected design remain in sibling owner docs. |
+| `ALT-03` | Add a global privacy policy document instead of a feature support template | Rejected as out of scope. Issue 16 asks for a feature support template, not a repository-wide legal/security policy. |
+
+## Trade-offs
+
+| Trade-off ID | Decision | Benefit | Cost / Risk |
+| --- | --- | --- | --- |
+| `TRD-01` | Use a dedicated support template rather than expanding existing support docs | Clear owner boundary and lower risk of privacy/source facts being scattered across canonical docs | Adds one more optional template and index route |
+| `TRD-02` | Include local IDs for source and boundary rows | Makes review and traceability precise | Requires updating support ID taxonomy in feature-flow |
+| `TRD-03` | Keep source examples abstracted rather than copied | Prevents downstream-specific leakage into generic template | Template may be less detailed than the original downstream artifacts |
+
+## Accepted Local Decisions
+
+- `SD-01` The new support template is named `privacy-source-boundary.md` to cover both privacy constraints and source inventory provenance in one feature-local support artifact.
+- `SD-02` The support template uses `doc_kind: feature-support` and `doc_function: reference`; it must not use `evidence` as a default doc function because the template is not itself execution evidence.
+- `SD-03` The template should include local support IDs for privacy/source rows but must not introduce canonical `REQ-*`, `SC-*`, `CHK-*`, `EVID-*`, `SOL-*` or `STEP-*`.
+- `SD-04` The template should include "allowed metadata" and "explicitly excluded data" as separate sections because issue 16 acceptance depends on preventing unauthorized reads/storage/citation, not only documenting source confidence.
+
+## Contracts
+
+| Contract ID | Input / Output | Producer / Consumer | Semantics / Constraints |
+| --- | --- | --- | --- |
+| `CTR-01` | New support template wrapper | Template maintainer / feature authors | Wrapper frontmatter remains `doc_function: template`; instantiated frontmatter stays inside embedded contract. |
+| `CTR-02` | Instantiated support doc contract | Feature authors / reviewers | Instantiated doc is `doc_kind: feature-support`, `doc_function: reference`, and declares `must_not_define` for scope, selected design, acceptance criteria, canonical checks, evidence contract and implementation sequence. |
+| `CTR-03` | Source inventory rows | Feature authors / reviewers | Rows must capture source identity/class, availability/status, confidence, safe use and privacy boundary without exposing private raw contents. |
+| `CTR-04` | Excluded data rows | Feature authors / reviewers | Rows must state what must not be read/stored/cited and what explicit permission or owner change would be required before access. |
+
+## Invariants
+
+- `INV-01` Support docs do not own requirements, selected design, canonical acceptance inventory, canonical evidence contract or execution sequence.
+- `INV-02` Generic template docs must not contain downstream-specific `zelma`, Codex session internals, concrete runtime details, raw prompt/transcript/log schemas or secrets.
+- `INV-03` Source confidence/status must be documented as evidence quality for a source claim, not as permission to read private content.
+- `INV-04` Allowed metadata must be narrower than source existence; source existence alone does not authorize reading raw content.
+
+## Failure Modes
+
+- `FM-01` Privacy/source support doc becomes a hidden requirements owner. Mitigation: frontmatter `must_not_define`, role section and feature-flow wording must route changed requirements back to `brief.md`.
+- `FM-02` Template examples leak downstream runtime specifics. Mitigation: use generic source classes and verify with `CHK-04`.
+- `FM-03` Confidence/status is mistaken for access permission. Mitigation: keep confidence inventory and allowed/excluded data sections separate.
+- `FM-04` Agents cite or store raw private artifacts as evidence. Mitigation: evidence section must distinguish allowed evidence carriers from excluded raw source contents.
+
+## Rollout / Backout
+
+| Stage ID | Stage | Entry condition | Backout |
+| --- | --- | --- | --- |
+| `RB-01` | Documentation template update | `brief.md` and `design.md` active | Revert touched docs in this feature's change surface before implementation is published |
+| `RB-02` | Index/link verification | Template and routing edits complete | Restore previous index entries and rerun index audit |
+
+## ADR / External Design Dependencies
+
+| Artifact | Current status | Used for | Rule |
+| --- | --- | --- | --- |
+| `none` | `n/a` | No ADR dependency | Feature-local decisions stay in `SD-*` / `decision-log.md` |
+
+## Traceability
+
+| Requirement ID | Solution refs | Contracts / invariants | Failure / rollout refs |
+| --- | --- | --- | --- |
+| `REQ-01` | `SOL-01`, `TRD-01`, `C4-00`, `SD-01` | `CTR-01`, `CTR-02`, `INV-01` | `FM-01`, `RB-01` |
+| `REQ-02` | `SOL-01`, `SD-03`, `SD-04`, `TRD-02` | `CTR-03`, `CTR-04`, `INV-03`, `INV-04` | `FM-03`, `FM-04` |
+| `REQ-03` | `SOL-02`, `SOL-03` | `CTR-02`, `INV-01` | `FM-01`, `RB-01` |
+| `REQ-04` | `SOL-05`, `TRD-03` | `INV-02` | `FM-02` |
+| `REQ-05` | `SOL-04` | `CTR-01` | `RB-02` |

--- a/memory-bank/features/FT-016/implementation-plan.md
+++ b/memory-bank/features/FT-016/implementation-plan.md
@@ -1,0 +1,164 @@
+---
+title: "FT-016: Implementation Plan"
+doc_kind: feature
+doc_function: derived
+purpose: "Execution-план реализации FT-016. Фиксирует discovery context, шаги, риски и test strategy без переопределения canonical problem или solution facts."
+derived_from:
+  - brief.md
+  - design.md
+  - decision-log.md
+status: archived
+audience: humans_and_agents
+must_not_define:
+  - ft_016_scope
+  - ft_016_selected_design
+  - ft_016_acceptance_criteria
+  - ft_016_blocker_state
+---
+
+# FT-016: Implementation Plan
+
+## Цель текущего плана
+
+Выполнить documentation-only feature из issue 16: добавить generic privacy/source-boundary support template, подключить его к feature-flow/template routing и собрать evidence по canonical checks из `brief.md`.
+
+## Grounding / Support References
+
+| Document | Role in this plan | Facts reused | Conflict action |
+| --- | --- | --- | --- |
+| `brief.md` | canonical problem / verify owner | `REQ-*`, `NS-*`, `SC-*`, `NEG-*`, `CHK-*`, `EVID-*` | Update `brief.md` first |
+| `design.md` | solution owner | `SOL-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` | Update `design.md` or decision log first |
+| `decision-log.md` | FPF decision ledger | `DL-*` decisions and consequences | Update decision log if a blocking question is resolved |
+| `memory-bank/flows/templates/feature/support/runtime-surfaces.md` | local support-template reference pattern | wrapper/instantiated frontmatter pattern and non-ownership language | Mirror structure, not runtime-surface semantics |
+| `memory-bank/flows/templates/feature/support/use-cases.md` | local support-template reference pattern | companion-doc role and traceability wording | Mirror support boundary wording |
+
+## Current State / Reference Points
+
+| Path / module | Current role | Why relevant | Reuse / mirror |
+| --- | --- | --- | --- |
+| `memory-bank/flows/feature-flow.md` | canonical feature flow and support doc rules | New support doc trigger and ownership limits belong here | Add one optional support-doc row and support ID taxonomy |
+| `memory-bank/flows/templates/README.md` | template index | New template must be discoverable | Add index route |
+| `memory-bank/flows/templates/feature/README.md` | feature package README template | Downstream routes mention support docs by lifecycle | Add privacy/source-boundary route when support docs are listed |
+| `memory-bank/flows/templates/feature/brief.md` | canonical feature brief template | Design/support decision wording may need source-boundary trigger guidance | Add guidance without moving solution facts into brief |
+| `memory-bank/flows/templates/feature/design.md` | feature design template | Design packs may include privacy/source-boundary support refs | Add guidance without making support doc solution owner |
+| `memory-bank/flows/templates/feature/implementation-plan.md` | execution plan template | Plan grounding may import support refs and manual-only gaps | Add optional support ref and test strategy guidance |
+| `memory-bank/flows/templates/feature/support/` | support template directory | Target location for new template | Follow wrapper-template structure |
+| `memory-bank/features/README.md` | feature package index | New package should be discoverable | Add `FT-016` route |
+| `scripts/check_memory_bank_index.py` | local link/index audit | Required lightweight repo check | Run after edits |
+
+## Test Strategy
+
+| Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites / commands | Required CI suites / jobs | Manual-only gap / justification | Manual-only approval ref |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Template/index discoverability | `REQ-01`, `REQ-05`, `SC-01`, `CHK-01`, `CHK-05`, `SOL-01`, `SOL-04` | `check_memory_bank_index.py` audits existing memory-bank index/link expectations | Update indexes and run audit | `python3 scripts/check_memory_bank_index.py`; `rg -n "privacy-source-boundary|Privacy / Source Boundary|source-boundary" memory-bank/flows memory-bank/features/README.md` | Same audit/check commands if CI exists | none | `none` |
+| Template content coverage | `REQ-02`, `SC-02`, `NEG-01`, `NEG-02`, `CHK-02`, `SOL-01`, `SD-03`, `SD-04` | No automated semantic checker | Manual structured review against required sections | `sed -n '1,260p' memory-bank/flows/templates/feature/support/privacy-source-boundary.md` | n/a | Manual review is acceptable because repo has no semantic template linter | `none` |
+| Routing and owner boundaries | `REQ-03`, `SC-03`, `CHK-03`, `SOL-02`, `SOL-03`, `INV-01` | Existing docs encode owner boundaries | Manual review plus index audit | `sed -n` review of touched flow/templates; `python3 scripts/check_memory_bank_index.py` | Same audit if CI exists | Manual review for semantic ownership wording | `none` |
+| Generic leakage guard | `REQ-04`, `NEG-01`, `CHK-04`, `SOL-05`, `INV-02` | No existing leakage checker | Search for downstream-specific terms in generic surfaces | `rg -n "zelma|Codex session|session_meta|zellij|\\.zelma|process_argv" memory-bank/flows/templates memory-bank/flows/feature-flow.md` | Same search if CI exists | none | `none` |
+
+## Open Questions / Ambiguities
+
+No unresolved `OQ-*` remain after FPF decisions in `decision-log.md`.
+
+## Resolved Questions
+
+| Decision ref | Question | Resolution | Consequence |
+| --- | --- | --- | --- |
+| `DL-02` | Should the support template be named `privacy-source-boundary.md` or split into separate privacy-boundary and source-inventory templates? | Use one combined support template | `PRE-02` can be satisfied without human gate |
+| `DL-03` | Should the support doc default to `doc_function: evidence` or `reference`? | Use `doc_function: reference` | `PRE-01` can be satisfied without human gate |
+
+## Environment Contract
+
+| Area | Contract | Used by | Failure symptom |
+| --- | --- | --- | --- |
+| setup | Run from repository root in this worktree | `STEP-01` - `STEP-07` | Relative paths fail or index script cannot find `memory-bank/` |
+| test | Lightweight checks only; no app build/runtime exists | `CHK-01` - `CHK-05` | Attempts to run nonexistent app tests |
+| access / network / secrets | No secrets required. External source examples are read-only context and must not be copied into generic templates | `STEP-01`, `STEP-03`, `STEP-06` | Generic template contains downstream runtime terms or private/raw source content |
+
+## Preconditions
+
+| Precondition ID | Canonical ref | Required state | Used by steps | Blocks start |
+| --- | --- | --- | --- | --- |
+| `PRE-01` | `CON-01`, `SD-02`, `INV-01` | Support doc remains non-canonical owner | `STEP-03`, `STEP-04`, `STEP-05` | yes |
+| `PRE-02` | `SD-01`, `DL-02` | Single-template naming decision accepted locally | `STEP-03`, `STEP-04`, `STEP-05` | yes |
+| `PRE-03` | `INV-02`, `NS-02` | Downstream specifics are barred from generic template surfaces | `STEP-03`, `STEP-06`, `STEP-07` | yes |
+
+## Workstreams
+
+| Workstream | Implements | Result | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| `WS-1` | `REQ-01`, `REQ-02`, `SOL-01`, `CTR-01` - `CTR-04` | New support template | agent | `PRE-01`, `PRE-02`, `PRE-03` |
+| `WS-2` | `REQ-03`, `REQ-05`, `SOL-02` - `SOL-04` | Routing/index updates | agent | `WS-1` |
+| `WS-3` | `REQ-04`, `SOL-05`, `INV-02` | Generic leakage review and evidence | agent | `WS-1`, `WS-2` |
+
+## Approval Gates
+
+| Approval Gate ID | Trigger | Applies to | Why approval is required | Approver / evidence |
+| --- | --- | --- | --- | --- |
+| `AG-01` | A proposed change would introduce a global privacy/legal policy, runtime behavior, or downstream-specific implementation contract | `STEP-03` - `STEP-05` | This would exceed issue 16 and feature scope | Human approval in issue/PR comment |
+
+## Порядок работ
+
+| Step ID | Actor | Implements | Goal | Touchpoints | Artifact | Verifies | Evidence IDs | Check command / procedure | Blocked by | Needs approval | Escalate if |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `STEP-01` | agent | `REQ-05` | Confirm current template/support index shape | `memory-bank/flows/templates/`, `memory-bank/features/README.md` | Discovery notes in this plan | `CHK-05` | `EVID-05` | `rg --files memory-bank/flows/templates memory-bank/features` | none | `none` | Reference pattern contradicts feature-flow |
+| `STEP-02` | agent | `REQ-01`, `REQ-02`, `SOL-01` | Draft `privacy-source-boundary.md` wrapper template | `memory-bank/flows/templates/feature/support/privacy-source-boundary.md` | New template | `CHK-02` | `EVID-02` | Structured review against `REQ-02` and `CTR-*` | `PRE-01`, `PRE-02`, `PRE-03` | `AG-01` if scope expands | Template needs canonical facts owned by `brief.md` or `design.md` |
+| `STEP-03` | agent | `REQ-03`, `SOL-02` | Update feature-flow support doc rules and support ID taxonomy | `memory-bank/flows/feature-flow.md` | Flow update | `CHK-03` | `EVID-03` | Review optional support docs and stable identifiers sections | `STEP-02` | `AG-01` if new global policy is proposed | Flow change affects unrelated feature lifecycle rules |
+| `STEP-04` | agent | `REQ-03`, `REQ-05`, `SOL-03`, `SOL-04` | Update feature/templates navigation and optional support refs | `memory-bank/flows/templates/README.md`, `memory-bank/flows/templates/feature/*.md`, `memory-bank/features/README.md` | Routing/index updates | `CHK-01`, `CHK-03`, `CHK-05` | `EVID-01`, `EVID-03`, `EVID-05` | Search and index audit | `STEP-02`, `STEP-03` | `none` | Index script reports missing expected route |
+| `STEP-05` | agent | `REQ-04`, `SOL-05` | Check generic leakage | `memory-bank/flows/templates`, `memory-bank/flows/feature-flow.md` | Leakage search output | `CHK-04` | `EVID-04` | `rg -n "zelma|Codex session|session_meta|zellij|\\.zelma|process_argv" memory-bank/flows/templates memory-bank/flows/feature-flow.md` | `STEP-02` - `STEP-04` | `none` | Search returns downstream-specific terms |
+| `STEP-06` | agent | `REQ-01` - `REQ-05` | Run final lightweight checks | Full touched docs | Check outputs | `CHK-05` | `EVID-05` | `python3 scripts/check_memory_bank_index.py && git diff --check` | `STEP-05` | `none` | Link/index or whitespace check fails |
+| `STEP-07` | agent | `REQ-01` - `REQ-05` | Capture final verify/evidence summary | Feature package / final report | Evidence summary | `CHK-01` - `CHK-05` | `EVID-01` - `EVID-05` | Summarize command outputs and review verdicts | `STEP-06` | `none` | Any canonical check remains failing |
+
+## Parallelizable Work
+
+- `PAR-01` Manual review of template content and routing wording can happen after `STEP-04` while command checks run.
+- `PAR-02` Do not parallelize edits to `feature-flow.md` and template index wording because they share support-doc taxonomy.
+
+## Checkpoints
+
+| Checkpoint ID | Refs | Condition | Evidence IDs |
+| --- | --- | --- | --- |
+| `CP-01` | `STEP-02`, `CHK-02`, `SOL-01` | New template contains required sections and owner-boundary wording | `EVID-02` |
+| `CP-02` | `STEP-03`, `STEP-04`, `CHK-01`, `CHK-03` | Routing/index updates are discoverable and ownership-safe | `EVID-01`, `EVID-03` |
+| `CP-03` | `STEP-05`, `STEP-06`, `CHK-04`, `CHK-05` | No downstream leakage in generic surfaces; index/diff checks pass | `EVID-04`, `EVID-05` |
+
+## Execution Risks
+
+| Risk ID | Risk | Impact | Mitigation | Trigger |
+| --- | --- | --- | --- | --- |
+| `ER-01` | Support template becomes too project-specific | Violates `REQ-04` and makes template non-portable | Keep examples generic and run `CHK-04` | Downstream terms appear in generic surfaces |
+| `ER-02` | Support doc ownership blurs with canonical docs | Contradicts feature-flow and causes review ambiguity | Repeat `must_not_define` and conflict-action wording | New template contains `REQ-*`, `SOL-*` or `STEP-*` as owned facts |
+| `ER-03` | Index script expects README updates beyond obvious navigation | Blocks `CHK-05` | Read script output and update only required indexes | `check_memory_bank_index.py` fails |
+
+## Stop Conditions / Fallback
+
+| Stop ID | Related refs | Trigger | Immediate action | Safe fallback state |
+| --- | --- | --- | --- | --- |
+| `STOP-01` | `NS-02`, `INV-02`, `CHK-04` | Generic surfaces require downstream runtime details to be useful | Stop and open human gate | Keep feature package docs; do not publish template change |
+| `STOP-02` | `AG-01`, `NS-03` | Work requires global privacy/legal policy or runtime behavior | Stop and ask for explicit scope decision | Documentation package remains planned |
+| `STOP-03` | `CHK-05` | Index audit exposes broad repository inconsistency unrelated to this feature | Document residual risk and avoid unrelated fixes | Touched docs only |
+
+## Plan-local Evidence
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checkpoints |
+| --- | --- | --- | --- | --- |
+| `EVID-09` | Review-improve cycle summaries | reviewer / implementer | Final response and, if needed, feature `decision-log.md` entries | `CP-01`, `CP-02`, `CP-03` |
+
+## Execution Result
+
+| Check ID | Result | Evidence carrier |
+| --- | --- | --- |
+| `CHK-01` | pass | Local `rg -n "privacy-source-boundary\|Privacy / Source Boundary\|source-boundary" memory-bank/flows memory-bank/features/README.md` output showed the new support template and routing/index references. |
+| `CHK-02` | pass | Manual review of `memory-bank/flows/templates/feature/support/privacy-source-boundary.md` confirmed allowed metadata, excluded data, source inventory confidence/status, owner boundaries and test evidence boundary sections. |
+| `CHK-03` | pass | Manual review confirmed routing/ownership updates in `memory-bank/flows/feature-flow.md`, feature README, brief, design and implementation-plan templates. |
+| `CHK-04` | pass | Local leakage search for downstream-specific source/runtime terms in generic template surfaces returned no matches. |
+| `CHK-05` | pass | `python3 scripts/check_memory_bank_index.py` and `git diff --check` passed locally. |
+
+Human gate: none. No approval gate was triggered.
+
+## Готово для приемки
+
+- Все workstreams завершены или явно остановлены через `STOP-*`.
+- Все checkpoints имеют evidence.
+- Required local suites зелёные.
+- Manual-only gaps закрыты review verdicts; approval gates не требуются, если scope не расширялся.
+- Финальная приемка идёт по `brief.md` `Verify`, а не по этому checklist.

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -29,3 +29,8 @@ audience: humans_and_agents
 - Базовый формат: `FT-XXX/`
 - Вместо `XXX` используй идентификатор, принятый в проекте: issue id, ticket id или другой стабильный ключ
 - Один package = одна delivery-единица
+
+## Packages
+
+- [FT-016: Privacy / Source Boundary Support Template](FT-016/README.md)
+  Читать, когда нужно: issue 16, generic privacy/source-boundary support template, source inventory confidence/status, allowed/excluded source data boundaries.

--- a/memory-bank/flows/feature-flow.md
+++ b/memory-bank/flows/feature-flow.md
@@ -45,7 +45,7 @@ audience: humans_and_agents
 12. **Связь с task tracker.** При создании feature package агент обязан добавить в исходную задачу или ticket ссылку на `brief.md`, а после появления downstream-документов — ссылки на существующие `design.md` и `implementation-plan.md`.
 13. Если фича является частью более крупной инициативы, `brief.md` может зависеть от PRD из `memory-bank/prd/`, но PRD не заменяет сам feature package.
 14. Если фича создает новый устойчивый сценарий проекта или materially changes существующий, соответствующий `UC-*` в `memory-bank/use-cases/` должен быть создан или обновлен до closure.
-15. Optional feature-support docs (`runtime-surfaces.md`, `ui-reference/README.md`, `use-cases/README.md`) допустимы для сложных фич как grounding / review / traceability aids. Они не становятся canonical owner problem space, solution space, acceptance inventory или execution sequencing.
+15. Optional feature-support docs (`runtime-surfaces.md`, `ui-reference/README.md`, `use-cases/README.md`, `privacy-source-boundary.md`) допустимы для сложных фич как grounding / review / traceability aids. Они не становятся canonical owner problem space, solution space, acceptance inventory или execution sequencing.
 16. Если фича зависит от upstream-документа инициативы, `brief.md` импортирует только релевантные upstream-ссылки, а не весь upstream scope.
 17. Если работа крупнее одной delivery-feature и требует roadmap, risk register или нескольких delivery units, не расширяй feature package; выбери подходящий upstream flow из `memory-bank/flows/` и веди каждую утвержденную delivery-единицу как отдельный feature package.
 
@@ -117,6 +117,7 @@ Support docs создаются только когда они снимают р
 | `ui-reference/README.md` | Фича меняет интерфейс, authoring flow, navigation, screen states или preview / editor UX | generic interface reference: screen map, interaction states, component expectations, copy/state semantics, mockup links and UI traceability | project-specific UI framework rules, product requirements, selected architecture, implementation steps |
 | `ui-reference/mockups/*.md` или другой linkable artifact | Любое interface change требует хотя бы low-fidelity mockup; default format — Markdown, но допустимы images, design-tool links или other artifacts, если они versionable / linkable | screen sketch, state examples, interaction notes | canonical acceptance inventory или final visual design system |
 | `use-cases/README.md` | Сценариев много, есть distinct happy/edge/error journeys, несколько user roles или нужен review-friendly `FUC -> REQ -> CHK` mapping | derived user-facing scenarios, edge/error cases, candidate test cases, traceability back to canonical refs | canonical `SC-*`, `NEG-*`, `CHK-*`, `EVID-*` |
+| `privacy-source-boundary.md` | Фича затрагивает logs, transcripts, diagnostics, observability artifacts, external metadata, source inventories или любой source class, где агенту нужны явные rules for read/store/cite/evidence use | source inventory, confidence/status, allowed metadata/data use, explicitly excluded data, owner/permission boundaries, evidence handling notes | requirements, selected design, acceptance criteria, canonical evidence contract, implementation sequence, global privacy/legal policy |
 
 Support docs должны ссылаться на canonical owners и явно писать, что они не подменяют `brief.md`, `design.md` или `implementation-plan.md`. Если support doc обнаруживает изменение scope, acceptance, selected design или execution sequence, сначала обновляется соответствующий canonical owner.
 
@@ -305,6 +306,10 @@ Canonical testing policy живёт в [../engineering/testing-policy.md](../eng
 | `UI-*` | interface screens, states, controls or interaction elements | `ui-reference/README.md` |
 | `FUC-*` | derived feature-local use cases | `use-cases/README.md` |
 | `TC-*` | derived test case candidates | `use-cases/README.md`, support docs |
+| `SRC-*` | source inventory entries / source classes / evidence carriers | `privacy-source-boundary.md` |
+| `ALLOW-*` | allowed metadata or data-use rows | `privacy-source-boundary.md` |
+| `EXCL-*` | explicitly excluded data classes or source-content boundaries | `privacy-source-boundary.md` |
+| `PERM-*` | owner / permission / escalation boundary rows | `privacy-source-boundary.md` |
 
 ### Required Minimum
 

--- a/memory-bank/flows/templates/README.md
+++ b/memory-bank/flows/templates/README.md
@@ -18,6 +18,7 @@ derived_from:
   - feature/design.md
   - feature/implementation-plan.md
   - feature/support/runtime-surfaces.md
+  - feature/support/privacy-source-boundary.md
   - feature/support/ui-reference.md
   - feature/support/use-cases.md
   - adr/ADR-XXX.md
@@ -47,6 +48,7 @@ audience: humans_and_agents
 - [FT-XXX: Design Template](feature/design.md) — canonical solution-space template для feature package. Отвечает на вопрос: как зафиксировать selected design, rationale, contracts, failure modes и design-pack routing.
 - [FT-XXX: Implementation Plan](feature/implementation-plan.md) — шаблон derived execution-плана. Отвечает на вопрос: как оформить sequencing и checkpoints после готовности upstream owners.
 - [FT-XXX: Runtime Surfaces Template](feature/support/runtime-surfaces.md) — optional support template для current runtime inventory, semantic mapping, context matrix и resolution tables.
+- [FT-XXX: Privacy / Source Boundary Template](feature/support/privacy-source-boundary.md) — optional support template для source inventory, allowed/excluded data boundaries, confidence/status и evidence handling.
 - [FT-XXX: UI Reference Template](feature/support/ui-reference.md) — optional support template для interface changes, screen map, interaction states и mockups.
 - [FT-XXX: Feature Use Cases Template](feature/support/use-cases.md) — optional support template для derived use cases, test case candidates и `FUC -> REQ -> CHK` review mapping.
 - [ADR-XXX: Short Decision Name](adr/ADR-XXX.md) — шаблон ADR. Отвечает на вопрос: как зафиксировать архитектурное решение.

--- a/memory-bank/flows/templates/feature/README.md
+++ b/memory-bank/flows/templates/feature/README.md
@@ -36,6 +36,10 @@ Downstream routes для living feature package добавляются по ме
   Читать, когда нужно: если по фиче существует связанный ADR, оформить или проверить его с корректным `decision_status`.
   Отвечает на вопрос: почему по фиче выбирается конкретное архитектурное или инженерное решение и на каком оно этапе.
 
+- `privacy-source-boundary.md`
+  Читать, когда нужно: если feature uses logs, transcripts, diagnostics, observability artifacts, external metadata, source inventories or other sources where read/store/cite/evidence boundaries must be explicit.
+  Отвечает на вопрос: какие source classes, allowed metadata, excluded data, confidence/status and owner boundaries apply without replacing canonical docs.
+
 ## Instantiated Frontmatter
 
 ```yaml
@@ -65,5 +69,5 @@ audience: humans_and_agents
   Читать, когда нужно: открыть instantiated canonical feature-документ сразу после bootstrap нового feature package.
   Отвечает на вопрос: где находятся problem space, canonical verify contract и stable IDs для этой фичи.
 
-После появления downstream-документов добавь сюда routes для `design.md`, `implementation-plan.md` и связанных ADR.
+После появления downstream-документов добавь сюда routes для `design.md`, `implementation-plan.md`, optional support docs и связанных ADR.
 ```

--- a/memory-bank/flows/templates/feature/brief.md
+++ b/memory-bank/flows/templates/feature/brief.md
@@ -25,6 +25,8 @@ canonical_for:
 
 Если фича меняет API, event, schema, file format, CLI, env contract, security boundary, financial calculation, integration contract, rollout/backout или требует alternatives/trade-off reasoning, зафиксируй `Design required: yes` и создай sibling `design.md` по шаблону `design.md`. Новые пакеты держат substantial design только в `design.md` / design-pack.
 
+Если feature depends on logs, transcripts, diagnostics, observability artifacts, external metadata or source inventories, consider optional `privacy-source-boundary.md` as support/reference. `brief.md` still owns scope, non-scope, acceptance scenarios, canonical checks and evidence contract.
+
 Используй стабильные идентификаторы по taxonomy из [../../feature-flow.md#stable-identifiers](../../feature-flow.md#stable-identifiers).
 
 ### Frontmatter Quick Ref

--- a/memory-bank/flows/templates/feature/design.md
+++ b/memory-bank/flows/templates/feature/design.md
@@ -28,6 +28,8 @@ canonical_for:
 
 Если solution-space разбит на несколько артефактов, `design.md` становится индексом design-pack и фиксирует owner-а каждого design fact. Не дублируй canonical факты из ADR, C4, data-flow или других design docs; ссылайся на них.
 
+Если solution reasoning depends on source access, source confidence or privacy/evidence boundaries, index optional `privacy-source-boundary.md` in the design pack as support/reference. It does not own selected `SOL-*`, `CTR-*`, `INV-*` or `FM-*`.
+
 ## Instantiated Frontmatter
 
 ```yaml
@@ -59,6 +61,7 @@ must_not_define:
 | --- | --- | --- |
 | `design.md` | Feature-local solution owner | `SOL-*`, `ALT-*`, `TRD-*`, `C4-*`, feature-local `CTR-*`, `INV-*`, `FM-*`, `RB-*` |
 | `../../adr/ADR-XXX.md` | Architecture decision | Какой design choice принадлежит ADR |
+| `privacy-source-boundary.md` | Optional source/privacy reference | `SRC-*`, `ALLOW-*`, `EXCL-*`, `PERM-*`; does not own selected design |
 
 ## Context
 

--- a/memory-bank/flows/templates/feature/implementation-plan.md
+++ b/memory-bank/flows/templates/feature/implementation-plan.md
@@ -47,6 +47,7 @@ derived_from:
   # - design.md
   # Optional support refs:
   # - runtime-surfaces.md
+  # - privacy-source-boundary.md
   # - ui-reference/README.md
   # - use-cases/README.md
 status: draft
@@ -76,6 +77,7 @@ must_not_define:
 | `brief.md` | canonical problem / verify owner | `REQ-*`, `SC-*`, `CHK-*`, `EVID-*` | Update `brief.md` first |
 | `design.md` / `none` | conditional solution owner | `SOL-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` | Update `design.md` or ADR first; if design is absent, promote new design facts before planning |
 | `runtime-surfaces.md` / `none` | optional grounding | `SURF-*`, `MAP-*`, context matrix | Promote changed design facts to `design.md` if design is required |
+| `privacy-source-boundary.md` / `none` | optional source/privacy reference | `SRC-*`, `ALLOW-*`, `EXCL-*`, `PERM-*`, evidence handling notes | Promote changed requirements to `brief.md`, changed design facts to `design.md`, and execution approvals to `AG-*` |
 | `ui-reference/README.md` / `none` | optional interface reference | `UI-*`, mockups, states | Promote changed requirements to `brief.md` or design facts to `design.md` if required |
 | `use-cases/README.md` / `none` | optional scenario companion | `FUC-*`, `TC-*` candidates | Keep canonical acceptance in `brief.md` |
 
@@ -90,6 +92,7 @@ must_not_define:
 ## Test Strategy
 
 Какие test surfaces должны быть обновлены по мере реализации. Этот раздел фиксирует expected automated coverage, required local/CI gates и manual-only exceptions для change surface, не переопределяя canonical test cases из `brief.md`.
+Если используется `privacy-source-boundary.md`, test strategy must state which evidence carriers are allowed, what must be redacted/summarized, and which source/privacy boundaries require `AG-*`.
 
 | Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites / commands | Required CI suites / jobs | Manual-only gap / justification | Manual-only approval ref |
 | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/memory-bank/flows/templates/feature/support/privacy-source-boundary.md
+++ b/memory-bank/flows/templates/feature/support/privacy-source-boundary.md
@@ -1,0 +1,128 @@
+---
+title: "FT-XXX: Privacy / Source Boundary Template"
+doc_kind: feature-support
+doc_function: template
+purpose: Governed wrapper-шаблон optional `privacy-source-boundary.md`. Читать, когда feature needs explicit source inventory, privacy/data-use boundaries, confidence/status notes and evidence handling rules.
+derived_from:
+  - ../../../feature-flow.md
+  - ../../../../dna/frontmatter.md
+status: active
+audience: humans_and_agents
+template_for: feature-support
+template_target_path: ../../../../features/FT-XXX/privacy-source-boundary.md
+canonical_for:
+  - feature_support_template_privacy_source_boundary
+---
+
+# FT-XXX: Privacy / Source Boundary Template
+
+Этот файл описывает wrapper-template. Инстанцируемый `privacy-source-boundary.md` живет внутри feature package как optional support/reference doc.
+
+## Wrapper Notes
+
+Создавай `privacy-source-boundary.md`, если feature touches logs, transcripts, diagnostics, observability artifacts, external metadata, source inventories or any source class where agents need explicit rules for what may be read, stored, cited, summarized or used as evidence.
+
+`privacy-source-boundary.md` не владеет requirements, selected design, acceptance criteria, canonical checks, evidence contract или implementation sequence. Если во время source inventory меняется scope или selected design, обнови sibling `brief.md`, required `design.md` или ADR до продолжения.
+
+Source confidence is not access permission. A source may be high-confidence and still explicitly excluded from reading, storage or citation.
+
+## Instantiated Frontmatter
+
+```yaml
+title: "FT-XXX: Privacy / Source Boundary"
+doc_kind: feature-support
+doc_function: reference
+purpose: "Privacy/source boundary reference для FT-XXX. Фиксирует allowed metadata, explicitly excluded data, source inventory confidence/status, owner boundaries and evidence handling without переопределения canonical problem, solution or execution facts."
+derived_from:
+  - brief.md
+  # Required only when design.md exists:
+  # - design.md
+status: draft
+audience: humans_and_agents
+must_not_define:
+  - ft_xxx_scope
+  - ft_xxx_selected_design
+  - ft_xxx_acceptance_criteria
+  - ft_xxx_evidence_contract
+  - implementation_sequence
+  - global_privacy_policy
+```
+
+## Instantiated Body
+
+```markdown
+# FT-XXX: Privacy / Source Boundary
+
+## Role
+
+Этот документ фиксирует feature-local source/privacy grounding. Canonical owners:
+
+- `brief.md` владеет problem space, scope, non-scope and canonical verify inventory.
+- `design.md`, если есть, владеет selected design, contracts, invariants and failure modes.
+- `implementation-plan.md` владеет execution sequencing, approval gates and check procedures.
+
+Use this support doc only to make source access, source confidence, privacy exclusions and evidence handling auditable for this feature.
+
+## Boundary Summary
+
+| Boundary | Summary | Related canonical refs |
+| --- | --- | --- |
+| Allowed use | What source-derived metadata or summaries may be used | `REQ-01`, `CON-01` |
+| Excluded use | What raw or private content must not be read, stored, cited or copied | `NS-01`, `NEG-01` |
+| Evidence use | Which evidence carriers are acceptable for checks without exposing excluded content | `CHK-01`, `EVID-01` |
+
+## Source Inventory / Confidence
+
+Confidence/status describes the quality and availability of the source claim. It does not grant permission to read private content.
+
+| Source ID | Source class / carrier | Owner / steward | Availability / status | Confidence | Safe use | Privacy boundary refs | Evidence refs |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `SRC-01` | Source class or carrier type | Who owns or approves this source | present / missing / candidate / unavailable | weak / medium / strong / unknown | What can safely be inferred or reused | `ALLOW-01`, `EXCL-01` | `EVID-01` |
+
+## Allowed Metadata / Data Use
+
+Allowed rows must be minimal. If a field or source class is not listed here, treat it as unavailable until the canonical owner updates the boundary.
+
+| Allowed ID | Source refs | Allowed metadata / data class | Allowed actions | Conditions / minimization | Related refs |
+| --- | --- | --- | --- | --- | --- |
+| `ALLOW-01` | `SRC-01` | Metadata or aggregate class that may be used | read / store / cite / summarize | Required minimization, redaction or retention notes | `REQ-01`, `CHK-01` |
+
+## Explicitly Excluded Data
+
+Excluded rows take precedence over allowed rows. Do not read, store, cite, summarize or copy excluded content unless a later owner-approved boundary explicitly changes this section.
+
+| Exclusion ID | Source refs | Must not read / store / cite | Why excluded | Permission or owner change required | Related refs |
+| --- | --- | --- | --- | --- | --- |
+| `EXCL-01` | `SRC-01` | Private raw content, secrets or other excluded data class | Privacy, safety, legal or scope reason | Who must approve and where approval is recorded | `NS-01`, `NEG-01`, `AG-01` |
+
+## Permission / Owner Boundaries
+
+Use this section when access depends on an owner, explicit approval, retention policy or external boundary. Approval gates used during execution still belong in `implementation-plan.md` as `AG-*`.
+
+| Permission ID | Trigger | Owner / approver | Allowed after approval | Still excluded | Approval / evidence path |
+| --- | --- | --- | --- | --- | --- |
+| `PERM-01` | What event or requested use needs approval | Responsible owner | What becomes allowed if approval is granted | What remains excluded | `AG-01` / issue / PR / audit path |
+
+## Test Evidence Boundary
+
+This section constrains evidence carriers for canonical checks. It does not create new canonical `CHK-*` or `EVID-*`; those remain in `brief.md`.
+
+| Check / evidence refs | Allowed evidence carrier | Required redaction or summary | Must not include | Producer / reviewer |
+| --- | --- | --- | --- | --- |
+| `CHK-01`, `EVID-01` | Log excerpt, report, fixture, screenshot, summary or other carrier allowed by this boundary | What must be redacted, aggregated or summarized | Excluded source content from `EXCL-*` | Who produces and reviews evidence |
+
+## Source Handling Rules
+
+- `SRC-*` rows inventory source classes or carriers; they do not authorize raw access by themselves.
+- `ALLOW-*` rows define the minimum allowed metadata or data use.
+- `EXCL-*` rows override `ALLOW-*` rows when they overlap.
+- `PERM-*` rows describe owner boundaries; execution-time approval gates still belong in `implementation-plan.md` as `AG-*`.
+- If this document discovers a new requirement or non-scope boundary, update `brief.md` first.
+- If this document discovers a selected design, contract, invariant or failure mode, update `design.md` or ADR first.
+
+## Notes For Implementation Plan
+
+- Which `SRC-*`, `ALLOW-*`, `EXCL-*` and `PERM-*` rows must be reflected in plan `PRE-*`, `AG-*`, `STEP-*` or `STOP-*`.
+- Which evidence carriers are acceptable for `CHK-*` without exposing excluded content.
+- Which source ambiguity should become `OQ-*` if it blocks execution.
+```


### PR DESCRIPTION
## Summary

- add `privacy-source-boundary.md` as a generic feature-support template for source inventory, allowed/excluded data boundaries, confidence/status, owner boundaries, and evidence handling
- wire the new support doc into `feature-flow.md`, feature templates, and template indexes
- add `FT-016` feature package with brief, design, implementation plan, and decision log for issue #16

Fixes #16.

## Validation

- `python3 scripts/check_memory_bank_index.py`
- `git diff --check`
- `rg -n "privacy-source-boundary|Privacy / Source Boundary|source-boundary" memory-bank/flows memory-bank/features/README.md`
- `rg -n "zelma|Codex session|session_meta|zellij|\.zelma|process_argv" memory-bank/flows/templates memory-bank/flows/feature-flow.md` (expected no matches)

## Notes

- No runtime/build app exists in this repository.
- No human gate was triggered.