### PR TITLE
[codex] add compact task flow

### DIFF
--- a/INTRO.md
+++ b/INTRO.md
@@ -29,17 +29,19 @@ Memory Bank - это не вики и не архив заметок. Это р�
 
 `epics/` - крупные инициативы: roadmap, decision log, risks и набор связанных delivery subissues. Epic не подменяет feature package.
 
+`tasks/` - compact packages для managed bugfix/chore/refactor задач, которым нужен durable context, но не нужен full feature package.
+
 `use-cases/` - канонические сценарии проекта. Это основной материал для постановки задач агентам и генерации тест-кейсов.
 
 `prompts/` - reusable prompt-документы: исходная формулировка, улучшенная copyable-версия и контекст применения.
 
-`flows/` - lifecycle flows и governed templates для PRD, use case, epic, feature package, ADR и process-документов.
+`flows/` - lifecycle flows и governed templates для task, PRD, use case, epic, feature package, ADR и process-документов.
 
 `engineering/` - инженерные правила: архитектура, frontend, testing policy, coding style, autonomy boundaries, git workflow.
 
 `ops/` - операционный контекст: development, stages, release, config и runbooks.
 
-`features/` - фича-паки. Каждая значимая фича получает `README.md`, canonical `feature.md` и, после Design Ready, derived `implementation-plan.md`.
+`features/` - фича-паки. Каждая значимая фича получает `README.md`, canonical `brief.md`, optional `design.md` и, после готовности upstream owners, derived `implementation-plan.md`.
 
 `adr/` - архитектурные решения. ADR нужен, когда команда выбирает подход и хочет сохранить не только решение, но и причины.
 
@@ -53,7 +55,7 @@ Memory Bank решает это через три механизма:
 
 - Single Source of Truth: каждый факт живет в одном месте;
 - Source Dependency Tree: при конфликте понятно, какой документ главнее;
-- Task Workflows и Feature Flow: задача получает подходящий уровень формализации, а средняя, большая или рискованная фича превращается в фича-пак, из которого агент может проектировать, реализовывать и проверять результат.
+- Task Workflows, Task Flow и Feature Flow: задача получает подходящий уровень формализации; small bugfix/refactor/chore может остаться compact task, а средняя, большая или рискованная фича превращается в фича-пак, из которого агент может проектировать, реализовывать и проверять результат.
 
 ## Рабочий процесс внедрения
 
@@ -63,23 +65,25 @@ Memory Bank решает это через три механизма:
 4. Адаптировать минимум четыре раздела: `product/`, `domain/`, `engineering/`, `ops/`.
 5. Завести первые use cases для текущего эпика или фичи.
 6. По use cases сформировать проверяемые тест-кейсы: автоматические и ручные.
-7. Для малых локальных задач использовать минимальный workflow из `memory-bank/flows/workflows.md`, не раздувая их до feature package без риска или необходимости.
-8. Для средней, большой или рискованной фичи создавать feature package: `README.md` как routing-слой и `feature.md` как canonical owner scope, design и verification.
-9. После Design Ready создавать `implementation-plan.md` как derived execution-документ с grounding, шагами, checkpoints и traceability к IDs из `feature.md`.
+7. Для малых локальных задач использовать минимальный workflow из `memory-bank/flows/workflows.md` и compact task profiles из `memory-bank/flows/task-flow.md`, не раздувая их до feature package без риска или необходимости.
+8. Для средней, большой или рискованной фичи создавать feature package: `README.md` как routing-слой, `brief.md` как canonical owner problem space и verify, и `design.md`, если нужен solution-space owner.
+9. После готовности `brief.md` и required `design.md` создавать `implementation-plan.md` как derived execution-документ с grounding, шагами, checkpoints и traceability к canonical IDs.
 10. Запускать агента на задачу через подходящий governed artifact: task, use case, feature package, PRD или epic, а не через длинное устное объяснение.
 11. После реализации обновлять Memory Bank, если появились новые факты, правила, риски или решения.
 
 ## Feature Flow
 
-Фича-пак разделяет задачу на canonical intent/design и derived execution.
+Фича-пак разделяет задачу на canonical problem space, conditional solution space и derived execution.
 
-`feature.md` - canonical owner delivery-единицы. Он фиксирует problem, outcome, scope (`REQ-*`), non-scope (`NS-*`), constraints, design, acceptance scenarios (`SC-*`), checks (`CHK-*`) и evidence contract (`EVID-*`).
+`brief.md` - canonical problem-space owner delivery-единицы. Он фиксирует problem, outcome, scope (`REQ-*`), non-scope (`NS-*`), constraints, design requirement decision, acceptance scenarios (`SC-*`), checks (`CHK-*`) и evidence contract (`EVID-*`).
 
-`README.md` внутри `features/FT-XXX/` - routing-слой. Он создается вместе с `feature.md` и добавляет ссылки на optional derived-документы только после их появления.
+`design.md` - conditional solution-space owner. Он создается только когда `brief.md` фиксирует `Design required: yes` и владеет selected design, contracts, invariants, failure modes и rollout/backout facts.
 
-`implementation-plan.md` появляется только после того, как `feature.md` стал design-ready. Это execution-документ: relevant paths, existing patterns, unresolved questions, test surfaces, execution environment, шаги, checkpoints и traceability к canonical IDs из `feature.md`.
+`README.md` внутри `features/FT-XXX/` - routing-слой. Он создается вместе с `brief.md` и добавляет ссылки на downstream-документы только после их появления.
 
-Раздел верификации в `feature.md` обязателен. Если агент не понимает, как проверить результат, он будет оптимизировать под "код написан", а не под "фича работает".
+`implementation-plan.md` появляется только после того, как `brief.md` и required `design.md` готовы. Это execution-документ: relevant paths, existing patterns, unresolved questions, test surfaces, execution environment, шаги, checkpoints и traceability к canonical IDs.
+
+Раздел верификации в `brief.md` обязателен. Если агент не понимает, как проверить результат, он будет оптимизировать под "код написан", а не под "фича работает".
 
 ## Контекст и перезапуск агентов
 
@@ -147,7 +151,7 @@ git diff --check
 Фича-пак:
 
 ```text
-Прочитай ./memory-bank/README.md и ./memory-bank/flows/feature-flow.md, затем создай feature package для задачи. Сначала инстанцируй README.md и feature.md; в feature.md обязательно зафиксируй scope, non-scope, design, acceptance scenarios, checks и evidence. implementation-plan.md создавай только после Design Ready.
+Прочитай ./memory-bank/README.md и ./memory-bank/flows/feature-flow.md, затем создай feature package для задачи. Сначала инстанцируй README.md и brief.md; в brief.md обязательно зафиксируй scope, non-scope, Design Requirement Decision, acceptance scenarios, checks и evidence. implementation-plan.md создавай только после готовности upstream owners.
 ```
 
 Ревью Memory Bank:
@@ -162,7 +166,7 @@ git diff --check
 - `product/`, `domain/`, `engineering/`, `ops/` адаптированы под проект.
 - Для текущего эпика заведены use cases.
 - По use cases есть автоматические или ручные проверки.
-- Средние, большие или рискованные фичи оформляются через feature package; малые локальные задачи проходят через минимальный workflow.
+- Средние, большие или рискованные фичи оформляются через feature package; малые bugfix/refactor/chore задачи проходят через minimal workflow или compact task package.
 - Спорные технические решения оформляются как ADR.
 - Скрипт проверки индексации проходит без errors.
 - Команда понимает: если факт нужен агенту, он должен быть записан в Memory Bank.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ AGENTS.md. Если страница не упомянются напрямую,
 
 - `memory-bank/dna/` — governance-ядро: SSoT, frontmatter, lifecycle, cross-references.
 - `memory-bank/flows/` — lifecycle flows и шаблоны для PRD/feature/ADR.
+- `memory-bank/tasks/` — optional compact packages для managed bugfix/chore/refactor задач без full feature package.
 - `memory-bank/product/` — заготовки для product context, vision, customers, metrics, marketing и roadmap.
 - `memory-bank/domain/` — заготовки для glossary, domain model, rules, states, events и context map.
 - `memory-bank/prd/` — место для instantiated Product Requirements Documents.

--- a/artifacts/ft-012/verify/chk-01/index-audit.txt
+++ b/artifacts/ft-012/verify/chk-01/index-audit.txt
@@ -1,0 +1,23 @@
+Memory-bank link audit
+Repo root: /Users/danil/worktrees/feature/issue-12-compact-task-flow-bugfix-refactor-chore
+Scope root: memory-bank
+Entrypoints: memory-bank/README.md
+Navigation depth threshold: 3
+Markdown files in scope: 82
+Index documents in scope: 17
+
+OK: no broken internal markdown links in scope.
+
+OK: no broken frontmatter markdown dependencies in scope.
+
+OK: no orphan markdown files in scope.
+
+OK: all scoped markdown files are reachable from the configured entrypoints via index navigation.
+
+OK: no documents are reachable only deeper than the configured threshold.
+
+Index compliance:
+  - OK
+
+Result: OK
+Machine-readable output: re-run with --json for a structured report suitable for auto-indexing.

--- a/artifacts/ft-012/verify/chk-02/manual-review.md
+++ b/artifacts/ft-012/verify/chk-02/manual-review.md
@@ -1,0 +1,32 @@
+# FT-012 Manual Review
+
+## Scope Verdict
+
+Pass.
+
+Reviewed against GitHub issue #12 and `memory-bank/features/FT-012/brief.md`:
+
+- Added generic `memory-bank/flows/task-flow.md`.
+- Added generic `memory-bank/flows/bugfix-flow.md`.
+- Added generic `memory-bank/flows/refactor-flow.md`.
+- Added `TASK-XXX` templates under `memory-bank/flows/templates/task/`.
+- Added `memory-bank/tasks/README.md` as optional destination for managed non-feature tasks.
+- Updated routing and indexes: `memory-bank/flows/workflows.md`, `memory-bank/flows/README.md`, `memory-bank/flows/templates/README.md`, `memory-bank/README.md`, root `README.md`, `INTRO.md`, and `dependency-tree.md`.
+
+## Boundary Verdict
+
+Pass.
+
+The compact task layer is distinct from `feature-flow`:
+
+- `task-flow.md` owns non-feature carrier/package lifecycle only.
+- `bugfix-flow.md` owns symptom/reproduction/root cause/fix boundary/regression coverage.
+- `refactor-flow.md` owns intent/invariants/change surface/checkpoints/verification.
+- `feature-flow.md` remains the owner for feature packages and solution/execution artifacts.
+- `TASK-XXX/` explicitly does not create `design.md` or `implementation-plan.md`; needing those artifacts is a promotion signal.
+
+## Source Sanitization Verdict
+
+Pass.
+
+Source-specific examples and terms from the source repository were not copied into target template docs. Source repository names appear only in FT-012 feature documentation as provenance and in the existing root source catalog.

--- a/artifacts/ft-012/verify/chk-03/source-scan.txt
+++ b/artifacts/ft-012/verify/chk-03/source-scan.txt
@@ -1,0 +1,1 @@
+No source-specific matches in target template docs.

--- a/artifacts/ft-012/verify/chk-04/promotion-scan.txt
+++ b/artifacts/ft-012/verify/chk-04/promotion-scan.txt
@@ -1,0 +1,55 @@
+memory-bank/flows/bugfix-flow.md:23:- `workflow_profile=bugfix-compact`;
+memory-bank/flows/bugfix-flow.md:24:- `workflow_profile=managed-task` и primary owner task package - `bugfix.md`.
+memory-bank/flows/bugfix-flow.md:26:Общие правила carrier/package, worktree, promotion и closure задает [`task-flow.md`](task-flow.md). Этот документ владеет только bugfix-процессом: symptom, reproduction, root cause, fix boundary и regression coverage.
+memory-bank/flows/bugfix-flow.md:57:- [ ] `contract_change=none` для `bugfix-compact`.
+memory-bank/flows/bugfix-flow.md:59:- [ ] Promotion triggers из [`workflows.md`](workflows.md) проверены.
+memory-bank/flows/bugfix-flow.md:71:Если root cause неизвестен, разрешены только discovery, logging, reproduction spec или diagnostic capture. Behavior-changing fix ждет известного `RC-*` или promotion.
+memory-bank/flows/refactor-flow.md:102:2. Если behavior change желателен или необходим, task повышается до `feature-package` или другого подходящего profile.
+memory-bank/flows/refactor-flow.md:105:5. Системный refactor с несколькими independent delivery units повышается минимум до `managed-task`, часто до `epic-package`.
+memory-bank/flows/refactor-flow.md:23:- `workflow_profile=refactor-small`;
+memory-bank/flows/refactor-flow.md:24:- `workflow_profile=managed-task` и primary owner task package - `refactor.md`.
+memory-bank/flows/refactor-flow.md:26:Общие правила carrier/package, worktree, promotion и closure задает [`task-flow.md`](task-flow.md). Этот документ владеет только refactor/chore-процессом: intent, behavior invariants, change surface, checkpoints и verification.
+memory-bank/flows/refactor-flow.md:56:- [ ] `contract_change=none` для `refactor-small`.
+memory-bank/flows/refactor-flow.md:58:- [ ] Promotion triggers из [`workflows.md`](workflows.md) проверены.
+memory-bank/flows/refactor-flow.md:70:Если проверяемые invariants нельзя сформулировать, refactor не готов к execution: сначала нужен discovery или promotion.
+memory-bank/flows/task-flow.md:106:- [ ] Routing Signature заполнен, включая `workflow_profile`.
+memory-bank/flows/task-flow.md:107:- [ ] Promotion triggers из [`workflows.md`](workflows.md) проверены.
+memory-bank/flows/task-flow.md:108:- [ ] Для compact profiles нет `risk=high/critical`.
+memory-bank/flows/task-flow.md:109:- [ ] `contract_change=none` для `tracker-only`, `bugfix-compact`, `refactor-small`.
+memory-bank/flows/task-flow.md:111:- [ ] Если есть `unknown` в `kind`, `risk`, `change_surface` или `contract_change`, задача не переходит в Task Ready без discovery или promotion.
+memory-bank/flows/task-flow.md:140:- [ ] Если появились promotion triggers, они не замаскированы: задача promoted или явно остановлена.
+memory-bank/flows/task-flow.md:145:Promotion обязателен, если появился любой trigger:
+memory-bank/flows/task-flow.md:33:Если задача создает новую capability, меняет устойчивый scenario, затрагивает API/schema/security/financial/integration/rollout contract или требует design reasoning, ее нужно повысить до `feature-package`, ADR или `epic-package` по promotion rules.
+memory-bank/flows/task-flow.md:39:| `tracker-only` | GitHub issue/PR с Routing Signature, boundary и verification evidence | none | `tiny/small`, `low` risk, без contract change, без durable owner doc |
+memory-bank/flows/task-flow.md:58:Используй [`bugfix-flow.md`](bugfix-flow.md). `task-flow` владеет carrier/package и promotion, `bugfix-flow` владеет symptom, reproduction, root cause, fix boundary и regression coverage.
+memory-bank/flows/task-flow.md:62:Используй [`refactor-flow.md`](refactor-flow.md). `task-flow` владеет carrier/package и promotion, `refactor-flow` владеет intent, behavior invariants, change surface, checkpoints и verification.
+memory-bank/flows/task-flow.md:78:5. В одном `TASK-XXX/` должен быть ровно один primary task owner: `bugfix.md` или `refactor.md`, кроме случаев, когда package явно служит routing-index для нескольких follow-up tasks. Если появляется несколько independent delivery units, создай отдельные `TASK-*` или promote в `epic-package`.
+memory-bank/flows/task-flow.md:79:6. `implementation-plan.md` внутри `TASK-XXX/` не создается. Sequencing и checkpoints должны помещаться в primary task owner. Если нужен полноценный execution contract, promote до `feature-package` или создай отдельный approved plan по upstream owner-решению.
+memory-bank/flows/task-flow.md:80:7. `design.md` внутри `TASK-XXX/` не создается. Если нужен solution-space owner, alternatives/trade-off reasoning, C4, migration strategy или rollout/backout design, promote до `feature-package` или ADR + feature package.
+memory-bank/flows/templates/task/bugfix.md:38:workflow_profile: bugfix-compact
+memory-bank/flows/templates/task/bugfix.md:57:| `contract_change` | `none` |
+memory-bank/flows/templates/task/bugfix.md:58:| `workflow_profile` | `bugfix-compact` |
+memory-bank/flows/templates/task/bugfix.md:60:Promotion check: если `contract_change != none`, `risk=high/critical` или root cause требует design reasoning, остановиться и поднять profile по `workflows.md`.
+memory-bank/flows/templates/task/package-README.md:33:workflow_profile: managed-task
+memory-bank/flows/templates/task/package-README.md:49:| `contract_change` | `none` |
+memory-bank/flows/templates/task/package-README.md:50:| `workflow_profile` | `managed-task` |
+memory-bank/flows/templates/task/package-README.md:52:Promotion check: если появляется capability, contract change, high/critical risk, design reasoning или несколько delivery units, остановиться и поднять profile по `workflows.md`.
+memory-bank/flows/templates/task/refactor.md:38:workflow_profile: refactor-small
+memory-bank/flows/templates/task/refactor.md:57:| `contract_change` | `none` |
+memory-bank/flows/templates/task/refactor.md:58:| `workflow_profile` | `refactor-small` / `managed-task` |
+memory-bank/flows/templates/task/refactor.md:60:Promotion check: если меняется observable behavior, contract, rollout, security/financial boundary или несколько bounded contexts, поднять profile по `workflows.md`.
+memory-bank/flows/workflows.md:127:| `tracker-only` | `tiny/small`, `low` risk, локальная правка без contract change | GitHub issue/PR: routing signature, short rationale, checks/evidence | Нужен durable owner doc, есть design decision или high-risk surface |
+memory-bank/flows/workflows.md:128:| `bugfix-compact` | Дефект с понятным symptom/repro/root cause и локальным fix | [`bugfix-flow.md`](bugfix-flow.md); GitHub issue/PR по шаблону [`templates/task/bugfix.md`](templates/task/bugfix.md); optional `memory-bank/tasks/TASK-XXX/README.md` + `bugfix.md`, если нужен durable context | Меняется API/schema/security/financial/integration/rollout или root cause требует design reasoning |
+memory-bank/flows/workflows.md:131:| `feature-package` | Новая или materially changed capability / delivery slice | `memory-bank/features/FT-XXX/` по [`feature-flow.md`](feature-flow.md) | Требуется roadmap/risk register/subissues для нескольких delivery units |
+memory-bank/flows/workflows.md:132:| `epic-package` | Инициатива крупнее одной delivery unit | `memory-bank/epics/EP-XXX/` по [`epic-flow.md`](epic-flow.md) | Есть только одна локальная delivery task |
+memory-bank/flows/workflows.md:137:## Promotion Rules
+memory-bank/flows/workflows.md:143:| Меняется API, event, schema, file format, CLI, security boundary, financial calculation, integration contract или operational rollout | `feature-package` или ADR + `feature-package` | Нужен solution-space owner и acceptance traceability |
+memory-bank/flows/workflows.md:144:| Bugfix требует alternatives/trade-off reasoning, migration strategy, rollout/backout или explicit failure-mode design | `managed-task` или `feature-package` | Issue/PR note перестает быть достаточным owner-ом решения |
+memory-bank/flows/workflows.md:145:| Refactor затрагивает несколько bounded contexts, shared abstractions или runtime topology | `managed-task` / `feature-package`; для серии задач - `epic-package` | Нужны checkpoints, invariants и stop conditions |
+memory-bank/flows/workflows.md:146:| Исправление создает новый устойчивый user/operator/system scenario | `feature-package` + обновление `UC-*` при необходимости | Это уже capability, а не только fix/chore |
+memory-bank/flows/workflows.md:148:| `risk=high/critical` или есть irreversible/external side effects | Минимум `managed-task`, часто `feature-package` | Нужны явные approvals, rollback/backout и durable evidence |
+memory-bank/flows/workflows.md:18:  - workflow_promotion_rules
+memory-bank/flows/workflows.md:59:| `contract_change` | `none`, `api`, `schema`, `event`, `security`, `financial`, `integration`, `rollout`, `unknown` | Включить promotion triggers |
+memory-bank/flows/workflows.md:63:| `workflow_profile` | `tracker-only`, `bugfix-compact`, `refactor-small`, `managed-task`, `feature-package`, `epic-package`, `incident-pir`, `unknown` | Зафиксировать итоговый profile selector-а |
+memory-bank/flows/workflows.md:65:Если `kind`, `risk`, `change_surface` или `contract_change` остаются `unknown`, агент не должен молча выбирать самый короткий путь. Нужно либо закрыть неизвестность через discovery, либо поднять задачу до более строгого profile.
+memory-bank/tasks/README.md:39:`implementation-plan.md` и `design.md` внутри `TASK-XXX/` не создаются. Если они стали нужны, task нужно повысить до `feature-package`, ADR или `epic-package`.

--- a/artifacts/ft-012/verify/chk-04/promotion-verdict.md
+++ b/artifacts/ft-012/verify/chk-04/promotion-verdict.md
@@ -1,0 +1,27 @@
+# FT-012 Promotion Trigger Review
+
+## Verdict
+
+Pass.
+
+Promotion triggers are present in the selector, task family flow, profile flows, task package destination, and task templates.
+
+## Checked Surfaces
+
+- `memory-bank/flows/workflows.md`
+- `memory-bank/flows/task-flow.md`
+- `memory-bank/flows/bugfix-flow.md`
+- `memory-bank/flows/refactor-flow.md`
+- `memory-bank/flows/templates/task/package-README.md`
+- `memory-bank/flows/templates/task/bugfix.md`
+- `memory-bank/flows/templates/task/refactor.md`
+- `memory-bank/tasks/README.md`
+
+## Required Promotion Triggers
+
+- Capability or stable scenario creation routes to `feature-package`.
+- API/event/schema/file format/CLI/security/financial/integration/rollout contract changes route to `feature-package` or ADR + `feature-package`.
+- Solution-space reasoning, ADR dependency, C4, migration strategy, rollout/backout, or explicit failure-mode design routes out of compact task profiles.
+- `risk=high/critical` routes to at least `managed-task`, often `feature-package`.
+- Multiple independent delivery units route to separate tasks or `epic-package`.
+- Repeated scope/design/evidence review findings require profile promotion instead of local-only fixes.

--- a/artifacts/ft-012/verify/chk-05/diff-check.txt
+++ b/artifacts/ft-012/verify/chk-05/diff-check.txt
@@ -1,0 +1,1 @@
+git diff --check passed with no output.

--- a/dependency-tree.md
+++ b/dependency-tree.md
@@ -53,8 +53,14 @@ memory-bank/dna/principles.md
     ├── memory-bank/engineering/testing-policy.md
     ├── memory-bank/features/README.md
     ├── memory-bank/flows/README.md
+    ├── memory-bank/flows/task-flow.md
+    ├── memory-bank/flows/bugfix-flow.md
+    ├── memory-bank/flows/refactor-flow.md
     ├── memory-bank/flows/feature-flow.md
     ├── memory-bank/flows/templates/README.md
+    ├── memory-bank/flows/templates/task/package-README.md
+    ├── memory-bank/flows/templates/task/bugfix.md
+    ├── memory-bank/flows/templates/task/refactor.md
     ├── memory-bank/flows/templates/adr/ADR-XXX.md
     ├── memory-bank/flows/templates/prd/PRD-XXX.md
     ├── memory-bank/flows/templates/use-case/UC-XXX.md
@@ -66,6 +72,7 @@ memory-bank/dna/principles.md
     ├── memory-bank/ops/runbooks/README.md
     ├── memory-bank/ops/stages.md
     ├── memory-bank/prd/README.md
+    ├── memory-bank/tasks/README.md
     ├── memory-bank/use-cases/README.md
     └── memory-bank/adr/README.md
 ```
@@ -78,8 +85,18 @@ memory-bank/dna/principles.md
 
 - Этот файл `dependency-tree.md` зависит от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), но сознательно живет вне `memory-bank/`.
 - [`memory-bank/flows/feature-flow.md`](memory-bank/flows/feature-flow.md) зависит и от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), и от [`memory-bank/dna/frontmatter.md`](memory-bank/dna/frontmatter.md).
-- [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md) зависит от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md) и [`memory-bank/flows/feature-flow.md`](memory-bank/flows/feature-flow.md).
-- [`memory-bank/flows/README.md`](memory-bank/flows/README.md) зависит сразу от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), [`memory-bank/flows/feature-flow.md`](memory-bank/flows/feature-flow.md), [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md) и [`memory-bank/flows/templates/README.md`](memory-bank/flows/templates/README.md).
+- [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md) зависит от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md), [`memory-bank/flows/bugfix-flow.md`](memory-bank/flows/bugfix-flow.md), [`memory-bank/flows/refactor-flow.md`](memory-bank/flows/refactor-flow.md) и [`memory-bank/flows/feature-flow.md`](memory-bank/flows/feature-flow.md).
+- [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md) зависит от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md), [`memory-bank/flows/bugfix-flow.md`](memory-bank/flows/bugfix-flow.md) и [`memory-bank/flows/refactor-flow.md`](memory-bank/flows/refactor-flow.md).
+- [`memory-bank/flows/bugfix-flow.md`](memory-bank/flows/bugfix-flow.md) зависит от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md) и [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md).
+- [`memory-bank/flows/refactor-flow.md`](memory-bank/flows/refactor-flow.md) зависит от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md) и [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md).
+- [`memory-bank/flows/README.md`](memory-bank/flows/README.md) зависит сразу от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md), [`memory-bank/flows/bugfix-flow.md`](memory-bank/flows/bugfix-flow.md), [`memory-bank/flows/refactor-flow.md`](memory-bank/flows/refactor-flow.md), [`memory-bank/flows/feature-flow.md`](memory-bank/flows/feature-flow.md), [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md) и [`memory-bank/flows/templates/README.md`](memory-bank/flows/templates/README.md).
+
+### Task-related Docs
+
+- [`memory-bank/tasks/README.md`](memory-bank/tasks/README.md) зависит от [`memory-bank/dna/governance.md`](memory-bank/dna/governance.md), [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md), [`memory-bank/flows/bugfix-flow.md`](memory-bank/flows/bugfix-flow.md), [`memory-bank/flows/refactor-flow.md`](memory-bank/flows/refactor-flow.md) и [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md).
+- [`memory-bank/flows/templates/task/package-README.md`](memory-bank/flows/templates/task/package-README.md) зависит от [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md), [`memory-bank/flows/bugfix-flow.md`](memory-bank/flows/bugfix-flow.md), [`memory-bank/flows/refactor-flow.md`](memory-bank/flows/refactor-flow.md) и [`memory-bank/dna/frontmatter.md`](memory-bank/dna/frontmatter.md).
+- [`memory-bank/flows/templates/task/bugfix.md`](memory-bank/flows/templates/task/bugfix.md) зависит от [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md), [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md), [`memory-bank/flows/bugfix-flow.md`](memory-bank/flows/bugfix-flow.md) и [`memory-bank/dna/frontmatter.md`](memory-bank/dna/frontmatter.md).
+- [`memory-bank/flows/templates/task/refactor.md`](memory-bank/flows/templates/task/refactor.md) зависит от [`memory-bank/flows/workflows.md`](memory-bank/flows/workflows.md), [`memory-bank/flows/task-flow.md`](memory-bank/flows/task-flow.md), [`memory-bank/flows/refactor-flow.md`](memory-bank/flows/refactor-flow.md) и [`memory-bank/dna/frontmatter.md`](memory-bank/dna/frontmatter.md).
 
 ### Feature-related Docs
 

--- a/memory-bank/README.md
+++ b/memory-bank/README.md
@@ -6,6 +6,7 @@ purpose: Корневая навигация по шаблонному memory-ba
 derived_from:
   - dna/principles.md
   - dna/governance.md
+  - flows/task-flow.md
 status: active
 audience: humans_and_agents
 ---
@@ -27,6 +28,9 @@ audience: humans_and_agents
 
 - [`epics/README.md`](epics/README.md)
   Читать, когда нужно: вести крупную инициативу через roadmap, decision log, risks и набор связанных delivery subissues.
+
+- [`tasks/README.md`](tasks/README.md)
+  Читать, когда нужно: вести managed non-feature bugfix/chore/refactor задачу в compact `TASK-XXX/` package без full feature package.
 
 - [`use-cases/README.md`](use-cases/README.md)
   Читать, когда нужно: зарегистрировать устойчивый пользовательский или операционный сценарий проекта.

--- a/memory-bank/features/FT-012/README.md
+++ b/memory-bank/features/FT-012/README.md
@@ -1,0 +1,35 @@
+---
+title: "FT-012: Compact Task Flow"
+doc_kind: feature
+doc_function: index
+purpose: "Навигация по документации feature package для compact task-flow bugfix/refactor/chore. Читать, чтобы перейти к canonical brief, design, implementation plan и FPF decision log."
+derived_from:
+  - ../../dna/governance.md
+  - brief.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-012: Compact Task Flow
+
+## О разделе
+
+Каталог фиксирует feature package для GitHub issue [#12](https://github.com/dapi/memory-bank/issues/12): добавить generic compact task-flow для bugfix/refactor/chore работ без превращения каждой маленькой задачи в full feature package.
+
+## Аннотированный индекс
+
+- [`brief.md`](brief.md)
+  Читать, когда нужно: проверить problem space, scope, non-scope, acceptance scenarios, checks и evidence contract.
+  Отвечает на вопрос: что должна доставить feature и как это будет принято.
+
+- [`design.md`](design.md)
+  Читать, когда нужно: проверить selected design для семейства `task-flow`, `bugfix-flow`, `refactor-flow`, templates и promotion boundaries.
+  Отвечает на вопрос: как compact task layer отделяется от feature/epic flow без скрытия high-risk или contract work.
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Читать, когда нужно: выполнить scoped docs changes, обновить индексы и собрать verification evidence.
+  Отвечает на вопрос: какие шаги, touchpoints, checks и stop conditions ведут feature к приемке.
+
+- [`decision-log.md`](decision-log.md)
+  Читать, когда нужно: проверить FPF-backed решения, закрытые в ходе review-improve.
+  Отвечает на вопрос: какие существенные неоднозначности закрыты, на каких фактах и с какими последствиями.

--- a/memory-bank/features/FT-012/brief.md
+++ b/memory-bank/features/FT-012/brief.md
@@ -1,0 +1,144 @@
+---
+title: "FT-012: Compact Task Flow"
+doc_kind: feature
+doc_function: canonical
+purpose: "Canonical brief для delivery-единицы issue #12. Фиксирует problem space, scope и verify contract для generic compact task-flow без смешения с solution space или execution plan."
+derived_from:
+  - ../../flows/feature-flow.md
+  - ../../flows/workflows.md
+  - ../../engineering/testing-policy.md
+  - https://github.com/dapi/memory-bank/issues/12
+status: active
+delivery_status: done
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+  - solution_space
+---
+
+# FT-012: Compact Task Flow
+
+## What
+
+### Problem
+
+GitHub issue [#12](https://github.com/dapi/memory-bank/issues/12) фиксирует, что текущий шаблон хорошо покрывает feature/epic delivery, но small bugfix/refactor/chore задачи получают слишком тяжелый full feature package. В source repository `alfagen/mercury` уже есть intermediate layer: compact issue/PR carrier или durable `TASK-XXX` package без превращения задачи в feature.
+
+### Outcome
+
+| Metric ID | Metric | Baseline | Target | Measurement method |
+| --- | --- | --- | --- | --- |
+| `MET-01` | Non-feature workflow coverage | В шаблоне есть `feature-flow` и `epic-flow`, но нет generic `task-flow` family | `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`, `TASK-XXX` templates и `tasks/README.md` доступны через индексы | `CHK-01`, `CHK-02` |
+| `MET-02` | Promotion safety | Compact путь не описан, риск спрятать feature/contract/high-risk work не управляется отдельными triggers | Compact profiles явно требуют promotion при capability, contract, design или high/critical risk trigger | `CHK-02`, `CHK-04` |
+| `MET-03` | Source sanitization | Source docs содержат downstream-specific examples and terms | В template не перенесены project-specific terms, issue ids или domain facts из source repo | `CHK-03` |
+
+### Scope
+
+- `REQ-01` Добавить generic governance docs: `memory-bank/flows/task-flow.md`, `memory-bank/flows/bugfix-flow.md`, `memory-bank/flows/refactor-flow.md`.
+- `REQ-02` Добавить governed templates для `TASK-XXX`: package README, bugfix и refactor/chore.
+- `REQ-03` Добавить `memory-bank/tasks/README.md` как optional destination для managed non-feature задач.
+- `REQ-04` Обновить `memory-bank/flows/README.md`, `memory-bank/flows/templates/README.md`, root `memory-bank/README.md` и related indexes/routing docs, которые должны раскрывать новый compact task layer.
+- `REQ-05` Сохранить generic template boundary: не переносить project-specific terms, source issue ids, examples или domain facts из `alfagen/mercury`.
+- `REQ-06` Зафиксировать promotion triggers так, чтобы feature/contract/high-risk/design work нельзя было спрятать в task package.
+
+### Non-Scope
+
+- `NS-01` Не переносить source-only `workflow-decision-log.md`, `workflow-metrics.md` или другие artifacts, которых нет в scope issue #12.
+- `NS-02` Не создавать sample `TASK-XXX` packages с downstream identifiers or domain facts from source repo.
+- `NS-03` Не заменять `feature-flow.md` или `epic-flow.md`; compact task layer должен быть отдельным routing/profile layer.
+- `NS-04` Не добавлять runtime application code, CI integration или external automation beyond documentation checks.
+- `NS-05` Не создавать project-specific policy для конкретного downstream продукта.
+
+### Constraints / Assumptions
+
+- `ASM-01` Source docs from `alfagen/mercury` are evidence for structure and semantics, but only generic rules can be adapted into this template.
+- `ASM-02` Current repository has no runtime application; verification is documentation/link/index oriented.
+- `CON-01` Governed docs under `memory-bank/` must have YAML frontmatter with `status` and valid local links.
+- `CON-02` `python3 scripts/check_memory_bank_index.py` is the canonical automated index/link audit named by issue #12.
+- `CON-03` Existing `feature-flow.md` remains canonical for feature packages; task docs must route promotion back to feature/ADR/epic when compact criteria fail.
+
+## Design Requirement Decision
+
+| Decision | Reason | Downstream owner |
+| --- | --- | --- |
+| `Design required: yes` | Issue #12 changes governance flows, templates, routing/indexes and promotion boundaries. Without a solution-space owner, the execution plan would have to decide how task, bugfix, refactor and feature flows relate. | `design.md` |
+
+## Verify
+
+### Exit Criteria
+
+- `EC-01` `task-flow.md`, `bugfix-flow.md` and `refactor-flow.md` exist, are generic governed docs and are discoverable through flow indexes.
+- `EC-02` `TASK-XXX` package README, bugfix and refactor templates exist under `memory-bank/flows/templates/task/` and are discoverable through templates indexes.
+- `EC-03` `memory-bank/tasks/README.md` exists as optional managed non-feature task destination and does not contain source repo examples.
+- `EC-04` Related indexes/routing docs link the new task family without making task-flow replace `feature-flow` or `epic-flow`.
+- `EC-05` Promotion triggers reject compact task usage for capability, contract, high/critical risk, design reasoning or multi-delivery-unit work.
+- `EC-06` Documentation checks pass and evidence is captured.
+
+### Traceability matrix
+
+| Requirement ID | Problem refs | Acceptance refs | Checks | Evidence IDs |
+| --- | --- | --- | --- | --- |
+| `REQ-01` | `ASM-01`, `CON-01`, `CON-03` | `EC-01`, `SC-01`, `SC-03` | `CHK-01`, `CHK-02`, `CHK-04` | `EVID-01`, `EVID-02`, `EVID-04` |
+| `REQ-02` | `ASM-01`, `CON-01` | `EC-02`, `SC-02` | `CHK-01`, `CHK-02` | `EVID-01`, `EVID-02` |
+| `REQ-03` | `ASM-01`, `CON-01` | `EC-03`, `SC-02` | `CHK-01`, `CHK-02`, `CHK-03` | `EVID-01`, `EVID-02`, `EVID-03` |
+| `REQ-04` | `CON-01`, `CON-02` | `EC-04`, `SC-04` | `CHK-01`, `CHK-02`, `CHK-04` | `EVID-01`, `EVID-02`, `EVID-04` |
+| `REQ-05` | `ASM-01`, `CON-01` | `EC-03`, `SC-05` | `CHK-03` | `EVID-03` |
+| `REQ-06` | `CON-03` | `EC-05`, `SC-03`, `NEG-01` | `CHK-02`, `CHK-04` | `EVID-02`, `EVID-04` |
+
+### Acceptance Scenarios
+
+- `SC-01` Reader opens `memory-bank/flows/workflows.md` and can choose a compact non-feature profile before defaulting to full `feature-flow`.
+- `SC-02` Reader opens `memory-bank/tasks/README.md` and can create a durable `TASK-XXX/` package with exactly one primary owner doc: `bugfix.md` or `refactor.md`.
+- `SC-03` Reader evaluates a task with capability, contract, design, high-risk or multi-delivery-unit trigger and is routed out of compact task package to feature/ADR/epic flow.
+- `SC-04` Reader starts at `memory-bank/README.md` and can reach task flows, task templates and `memory-bank/tasks/README.md` through documented indexes.
+- `SC-05` Reviewer searches source-specific terms from `alfagen/mercury` and finds no downstream domain examples in the template.
+
+### Negative / Edge Scenarios
+
+- `NEG-01` A bugfix/refactor candidate with API/schema/security/financial/integration/rollout contract change must not remain `tracker-only`, `bugfix-compact`, `refactor-small` or managed task without promotion.
+
+### Checks
+
+| Check ID | Covers | How to check | Expected result | Evidence path |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `EC-01`, `EC-02`, `EC-03`, `EC-04`, `SC-04` | `python3 scripts/check_memory_bank_index.py` | No broken links, frontmatter dependency issues, or unreachable/orphan docs | `artifacts/ft-012/verify/chk-01/` |
+| `CHK-02` | `EC-01`, `EC-02`, `EC-03`, `EC-05`, `SC-01`, `SC-02`, `SC-03`, `NEG-01` | Manual doc review of new flow/template docs against issue #12 and `feature-flow.md` boundaries | Compact task family is explicit, governed and does not redefine feature/epic ownership | `artifacts/ft-012/verify/chk-02/` |
+| `CHK-03` | `EC-03`, `SC-05`, `REQ-05` | `rg -n "alfagen|mercury|TASK-3446|rate-daemon|SlotDiagnostics|PositionAware|production log storm" memory-bank` | No matches outside feature docs where source provenance is intentionally cited | `artifacts/ft-012/verify/chk-03/` |
+| `CHK-04` | `EC-04`, `EC-05`, `REQ-06` | `rg -n "workflow_profile|Promotion|promotion|contract_change|feature-package|epic-package|ADR" memory-bank/flows memory-bank/tasks` plus reviewer inspection | Promotion triggers are present in selector, task flow and profile docs/templates | `artifacts/ft-012/verify/chk-04/` |
+| `CHK-05` | `EC-06` | `git diff --check` | No trailing whitespace or conflict markers | `artifacts/ft-012/verify/chk-05/` |
+
+### Test matrix
+
+| Check ID | Evidence IDs | Evidence path |
+| --- | --- | --- |
+| `CHK-01` | `EVID-01` | `artifacts/ft-012/verify/chk-01/` |
+| `CHK-02` | `EVID-02` | `artifacts/ft-012/verify/chk-02/` |
+| `CHK-03` | `EVID-03` | `artifacts/ft-012/verify/chk-03/` |
+| `CHK-04` | `EVID-04` | `artifacts/ft-012/verify/chk-04/` |
+| `CHK-05` | `EVID-05` | `artifacts/ft-012/verify/chk-05/` |
+
+### Evidence
+
+- `EVID-01` Output of `python3 scripts/check_memory_bank_index.py`.
+- `EVID-02` Review note confirming required flow/template docs and boundary separation.
+- `EVID-03` Source-specific term scan output.
+- `EVID-04` Promotion trigger scan and reviewer verdict.
+- `EVID-05` Output of `git diff --check`.
+
+### Evidence contract
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checks |
+| --- | --- | --- | --- | --- |
+| `EVID-01` | Link/index audit log | implementer | `artifacts/ft-012/verify/chk-01/index-audit.txt` | `CHK-01` |
+| `EVID-02` | Manual review note | implementer/reviewer | `artifacts/ft-012/verify/chk-02/manual-review.md` | `CHK-02` |
+| `EVID-03` | Source-specific scan log | implementer | `artifacts/ft-012/verify/chk-03/source-scan.txt` | `CHK-03` |
+| `EVID-04` | Promotion trigger scan log and verdict | implementer/reviewer | `artifacts/ft-012/verify/chk-04/promotion-scan.txt`, `artifacts/ft-012/verify/chk-04/promotion-verdict.md` | `CHK-04` |
+| `EVID-05` | Whitespace/conflict-marker audit log | implementer | `artifacts/ft-012/verify/chk-05/diff-check.txt` | `CHK-05` |
+
+### Verification Result
+
+- `CHK-01` pass: `artifacts/ft-012/verify/chk-01/index-audit.txt`.
+- `CHK-02` pass: `artifacts/ft-012/verify/chk-02/manual-review.md`.
+- `CHK-03` pass: `artifacts/ft-012/verify/chk-03/source-scan.txt`.
+- `CHK-04` pass: `artifacts/ft-012/verify/chk-04/promotion-scan.txt` and `artifacts/ft-012/verify/chk-04/promotion-verdict.md`.
+- `CHK-05` pass: `artifacts/ft-012/verify/chk-05/diff-check.txt`.

--- a/memory-bank/features/FT-012/decision-log.md
+++ b/memory-bank/features/FT-012/decision-log.md
@@ -1,0 +1,52 @@
+---
+title: "FT-012: Decision Log"
+doc_kind: feature
+doc_function: reference
+purpose: "Feature-local decision log для FPF-backed решений по issue #12. Фиксирует существенные неоднозначности, факты, выбранные решения и последствия без замены brief/design/plan."
+derived_from:
+  - brief.md
+  - design.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_012_scope
+  - ft_012_acceptance_criteria
+  - implementation_sequence
+---
+
+# FT-012: Decision Log
+
+## Принципы фиксации
+
+Decision log фиксирует только решения, которые materially влияют на целостность feature package или scope issue #12 и не требуют global ADR. Обоснования используют FPF в plain-language форме:
+
+- `Bounded Context`: source repository context and template repository context are separate; transfer requires explicit fit.
+- `Strict Distinction`: selector, family flow, profile flow, task package and feature package have different owners and must not replace each other.
+- `Evidence Graph`: claims cite concrete carriers such as issue #12, local docs and source files.
+- `Reasoning Cycle`: propose -> analyze -> test; new decisions stay tied to checks in `brief.md`.
+
+## Decisions
+
+### `DL-001`: Exclude Source-Only Workflow Decision/Metrics Docs
+
+| Field | Value |
+| --- | --- |
+| Status | accepted |
+| Closed in cycle | cycle 1 |
+| Question | Should FT-012 also add source-only `workflow-decision-log.md` and `workflow-metrics.md` because source `workflows.md` references them? |
+| Available facts | Issue #12 source list names `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`, `templates/task/*` and `tasks/README.md`. Issue #12 scope names those documents plus related indexes. Current repository has `workflows.md` but no `workflow-decision-log.md` or `workflow-metrics.md`. Source `workflows.md` references those source-only docs. |
+| FPF reasoning | Bounded Context: `alfagen/mercury` is a source context, while this repository is a generic template context; same filenames are not automatically in scope. Evidence Graph: the only requirement carrier for this feature is issue #12 plus existing local governance docs. Strict Distinction: metrics/decision-log governance for workflow evolution is different work from adding compact task carrier/profile flow. |
+| Decision | Do not add `workflow-decision-log.md` or `workflow-metrics.md` in FT-012. Keep them out of scope unless a later issue explicitly asks for workflow governance metrics/decision history. |
+| Consequences | `brief.md` records `NS-01`; `design.md` records `ALT-04` and `SD-02`. Implementation may update `workflows.md` selector, but must not import source-only governance docs. |
+
+### `DL-002`: Include `workflows.md` as Related Routing Scope
+
+| Field | Value |
+| --- | --- |
+| Status | accepted |
+| Closed in cycle | cycle 1 |
+| Question | Is updating `memory-bank/flows/workflows.md` in scope when issue #12 explicitly lists flow docs/templates/indexes but not this file by name? |
+| Available facts | Current `workflows.md` is the repository's task routing document and currently routes small/medium feature, bugfix, refactor and incident work without compact document profiles. Issue #12 acceptance requires compact task flow to explicitly differ from `feature-flow` and promotion triggers to prevent hiding feature/contract/high-risk work in task packages. Source `task-flow.md` applies after selector from `workflows.md`. |
+| FPF reasoning | Strict Distinction: `workflows.md` is the selector owner; `task-flow.md` is the family lifecycle owner; profile flows are specialized process owners. If selector is not updated, the new task family exists but has no canonical entrypoint. Deduction from acceptance: promotion triggers cannot be consistently applied if the canonical routing layer does not name compact profiles. |
+| Decision | Treat `workflows.md` as a related routing doc in `REQ-04` and update it during implementation. |
+| Consequences | `design.md` records `SD-01` and `TRD-03`; `implementation-plan.md` includes `memory-bank/flows/workflows.md` in `STEP-04`. |

--- a/memory-bank/features/FT-012/design.md
+++ b/memory-bank/features/FT-012/design.md
@@ -1,0 +1,120 @@
+---
+title: "FT-012: Design"
+doc_kind: feature
+doc_function: canonical
+purpose: "Solution-space документ для FT-012. Фиксирует выбранный подход к compact task-flow family, task templates, routing indexes и promotion boundaries без переопределения problem space или execution contract."
+derived_from:
+  - brief.md
+  - ../../flows/feature-flow.md
+  - https://github.com/dapi/memory-bank/issues/12
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_012_scope
+  - ft_012_acceptance_criteria
+  - ft_012_evidence_contract
+  - implementation_sequence
+---
+
+# FT-012: Design
+
+## Design Pack
+
+| Artifact | Role | Owns |
+| --- | --- | --- |
+| `design.md` | Feature-local solution owner | `SOL-*`, `ALT-*`, `TRD-*`, `C4-*`, feature-local `CTR-*`, `INV-*`, `FM-*`, `RB-*` |
+| `decision-log.md` | FPF-backed decision log | Local reasoning entries for decisions that do not need global ADR |
+
+## Context
+
+Issue #12 names a concrete source family from `alfagen/mercury`: `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`, `templates/task/*` and `tasks/README.md`. The target repository is a generic template, so the design problem is not whether to copy those files verbatim, but how to adapt their reusable process structure while keeping `feature-flow` as the owner of feature delivery and preventing compact task profiles from hiding higher-risk work.
+
+## C4 Applicability
+
+| C4 ID | Decision | Trigger / reason | Artifact |
+| --- | --- | --- | --- |
+| `C4-00` | `not required` | The feature changes documentation governance and templates only. It does not change runtime/deployable/container boundaries, external system interactions, APIs, schemas or storage topology. | `none` |
+
+## Selected Solution
+
+- `SOL-01` Add `task-flow.md` as the family-level non-feature lifecycle and carrier/package owner for `tracker-only`, `bugfix-compact`, `refactor-small` and `managed-task`, satisfying `REQ-01`, `REQ-06`.
+- `SOL-02` Add `bugfix-flow.md` and `refactor-flow.md` as profile-specific process owners, so root cause/regression coverage and behavior invariant/checkpoint rules do not live in the family flow, satisfying `REQ-01`.
+- `SOL-03` Add `memory-bank/flows/templates/task/package-README.md`, `bugfix.md` and `refactor.md` as governed wrapper templates for issue/PR compact notes and durable `TASK-XXX/` packages, satisfying `REQ-02`.
+- `SOL-04` Add `memory-bank/tasks/README.md` as an optional destination index for managed non-feature packages, satisfying `REQ-03`.
+- `SOL-05` Update `workflows.md` and navigation indexes so task profiles are discoverable before feature escalation, while preserving `feature-flow.md` and `epic-flow.md` as promotion targets, satisfying `REQ-04`, `REQ-06`.
+- `SOL-06` Apply source sanitization: adapt generic routing/profile/promotion semantics from source docs, but drop source project examples, source issue ids and source-only operational docs, satisfying `REQ-05`.
+
+## Alternatives Considered
+
+| Alternative ID | Option | Why not selected |
+| --- | --- | --- |
+| `ALT-01` | Keep using `feature-flow` for all bugfix/refactor/chore tasks | Rejected by issue #12 problem statement and acceptance: compact task flow must explicitly differ from feature-flow. |
+| `ALT-02` | Copy `alfagen/mercury` task docs verbatim | Rejected by `REQ-05`: source docs include downstream examples and references outside issue #12 scope. |
+| `ALT-03` | Add only a short section to `workflows.md`, without standalone `task-flow`, `bugfix-flow`, `refactor-flow` | Rejected by issue #12 scope, which explicitly asks for the three generic flow documents and `TASK-XXX` templates. |
+| `ALT-04` | Add `workflow-decision-log.md` and `workflow-metrics.md` because source `workflows.md` references them | Rejected for FT-012: those artifacts are not in issue #12 scope and would broaden the delivery unit. |
+
+## Trade-offs
+
+| Trade-off ID | Decision | Benefit | Cost / Risk |
+| --- | --- | --- | --- |
+| `TRD-01` | Use three flow docs rather than a single long task-flow | Clear ownership: family routing/package rules vs bugfix/refactor process details | More documents and more index links to keep coherent |
+| `TRD-02` | Keep task packages without `design.md` or `implementation-plan.md` | Prevents compact non-feature work from becoming hidden feature-flow | Some medium work must promote earlier rather than accumulating local task docs |
+| `TRD-03` | Update `workflows.md` selector as a related routing doc | Makes compact task profiles discoverable from the current task entrypoint | Requires careful wording to avoid implying feature-flow is deprecated |
+
+## Accepted Local Decisions
+
+- `SD-01` `workflows.md` is in implementation scope as a related canonical routing doc because compact profiles cannot be reliably discovered from indexes alone.
+- `SD-02` Source-only `workflow-decision-log.md` and `workflow-metrics.md` are excluded from FT-012; if needed later, they require a separate issue or feature package.
+- `SD-03` `TASK-XXX/` packages must not contain `design.md` or `implementation-plan.md`; the appearance of solution-space or execution-plan needs is a promotion signal.
+- `SD-04` `memory-bank/tasks/README.md` will not include source example packages. It may describe naming and package rules generically.
+
+## Contracts
+
+| Contract ID | Input / Output | Producer / Consumer | Semantics / Constraints |
+| --- | --- | --- | --- |
+| `CTR-01` | Routing Signature fields | `workflows.md` -> task/feature/epic flows | Must include enough fields to route kind, size, risk, change surface, contract change, design need, evidence need, owner doc need and workflow profile. |
+| `CTR-02` | Promotion triggers | `workflows.md`, `task-flow.md`, profile flows/templates -> agents/reviewers | Any capability, contract, high/critical risk, design reasoning or multi-delivery-unit trigger routes out of compact task profile. |
+| `CTR-03` | Durable task package shape | `task-flow.md`, task templates, `tasks/README.md` -> `memory-bank/tasks/TASK-XXX/` | Durable package contains `README.md` plus exactly one primary owner doc: `bugfix.md` or `refactor.md`, unless explicitly used as routing index for follow-ups. |
+| `CTR-04` | Source sanitization | Implementation -> template repository | Source provenance may be cited in FT-012 feature docs, but generated generic template docs must not embed source project terms or examples. |
+
+## Invariants
+
+- `INV-01` Compact task profiles never replace feature/epic/ADR ownership when promotion triggers are present.
+- `INV-02` `feature-flow.md` remains canonical for feature packages and must not be redefined by task-flow docs.
+- `INV-03` All new governed docs and templates include YAML frontmatter with `status`.
+- `INV-04` Navigation from `memory-bank/README.md` to task flows/templates/tasks destination remains reachable by link audit.
+- `INV-05` Source-specific facts from `alfagen/mercury` are not copied into generic target docs.
+
+## Failure Modes
+
+- `FM-01` Compact task docs become a loophole for feature/contract/high-risk work. Mitigation: duplicate promotion triggers in selector, task-flow, profile flows and templates.
+- `FM-02` New task docs are created but not discoverable. Mitigation: update root, flows, templates and tasks indexes and run `CHK-01`.
+- `FM-03` Source-specific examples leak into the generic template. Mitigation: run `CHK-03` against known source-specific terms and remove any matches outside FT-012 provenance.
+- `FM-04` Workflows selector conflicts with `feature-flow`. Mitigation: wording must say task-flow is a minimal non-feature profile family and feature-flow remains required for capability/contract/design work.
+
+## Rollout / Backout
+
+| Stage ID | Stage | Entry condition | Backout |
+| --- | --- | --- | --- |
+| `RB-01` | Add feature package docs | Issue #12 read and feature-flow reviewed | Remove `memory-bank/features/FT-012/` and related index link before implementation begins |
+| `RB-02` | Add task-flow family docs/templates/indexes | `brief.md` and `design.md` active | Revert new task docs/index links if link audit or review shows scope conflict |
+| `RB-03` | Verify and handoff | Docs complete and checks available | Leave feature in `planned` with explicit blockers if checks fail |
+
+## ADR / External Design Dependencies
+
+| Artifact | Current status | Used for | Rule |
+| --- | --- | --- | --- |
+| GitHub issue [#12](https://github.com/dapi/memory-bank/issues/12) | open | Scope, source list and acceptance | Source of requirements for FT-012 |
+| `alfagen/mercury` source docs | external source evidence | Reusable task-flow/profile/template semantics | Adapt only generic process structure; do not copy source-specific examples |
+| ADR | none | No reusable architecture decision required | Create ADR only if implementation changes cross-feature architecture policy beyond issue #12 |
+
+## Traceability
+
+| Requirement ID | Solution refs | Contracts / invariants | Failure / rollout refs |
+| --- | --- | --- | --- |
+| `REQ-01` | `SOL-01`, `SOL-02`, `ALT-03`, `TRD-01` | `CTR-01`, `CTR-02`, `INV-01`, `INV-02`, `INV-03` | `FM-01`, `FM-04`, `RB-02` |
+| `REQ-02` | `SOL-03`, `TRD-02` | `CTR-02`, `CTR-03`, `INV-01`, `INV-03` | `FM-01`, `RB-02` |
+| `REQ-03` | `SOL-04`, `SD-04` | `CTR-03`, `CTR-04`, `INV-03`, `INV-05` | `FM-02`, `FM-03`, `RB-02` |
+| `REQ-04` | `SOL-05`, `SD-01`, `TRD-03` | `CTR-01`, `CTR-02`, `INV-02`, `INV-04` | `FM-02`, `FM-04`, `RB-02` |
+| `REQ-05` | `SOL-06`, `ALT-02`, `SD-02`, `SD-04` | `CTR-04`, `INV-05` | `FM-03`, `RB-02` |
+| `REQ-06` | `SOL-01`, `SOL-05`, `SD-03` | `CTR-02`, `CTR-03`, `INV-01`, `INV-02` | `FM-01`, `FM-04`, `RB-02` |

--- a/memory-bank/features/FT-012/implementation-plan.md
+++ b/memory-bank/features/FT-012/implementation-plan.md
@@ -1,0 +1,155 @@
+---
+title: "FT-012: Implementation Plan"
+doc_kind: feature
+doc_function: derived
+purpose: "Execution-план реализации FT-012. Фиксирует discovery context, шаги, риски и test strategy без переопределения canonical problem и solution фактов."
+derived_from:
+  - brief.md
+  - design.md
+status: archived
+audience: humans_and_agents
+must_not_define:
+  - ft_012_scope
+  - ft_012_selected_design
+  - ft_012_acceptance_criteria
+  - ft_012_blocker_state
+---
+
+# План имплементации
+
+## Цель текущего плана
+
+Выполнить docs-only реализацию issue #12: добавить compact task-flow family, task templates, optional `memory-bank/tasks/` destination и обновить routing/index docs так, чтобы acceptance из `brief.md` проверялась локальными documentation checks.
+
+## Grounding / Support References
+
+| Document | Role in this plan | Facts reused | Conflict action |
+| --- | --- | --- | --- |
+| `brief.md` | canonical problem / verify owner | `REQ-*`, `SC-*`, `NEG-*`, `CHK-*`, `EVID-*` | Update `brief.md` first |
+| `design.md` | solution owner | `SOL-*`, `C4-*`, `SD-*`, `CTR-*`, `INV-*`, `FM-*`, `RB-*` | Update `design.md` or ADR first |
+| `decision-log.md` | local FPF decision ledger | Decisions that close important ambiguities | Update decision log if a new material ambiguity is resolved |
+| GitHub issue `#12` | external requirement source | Source list, scope and acceptance | Human gate if issue scope conflicts with implemented docs |
+| `alfagen/mercury` source docs | external source evidence | Generic flow/template patterns | Strip project-specific examples before target docs |
+
+## Current State / Reference Points
+
+| Path / module | Current role | Why relevant | Reuse / mirror |
+| --- | --- | --- | --- |
+| `memory-bank/flows/feature-flow.md` | Canonical feature package lifecycle | Task-flow must not redefine feature ownership | Reuse promotion boundary back to feature package |
+| `memory-bank/flows/workflows.md` | Current high-level task routing | Needs compact profiles and Routing Signature | Extend selector without deleting existing flow types |
+| `memory-bank/flows/README.md` | Flow navigation index | Must expose new flow docs | Add annotated links |
+| `memory-bank/flows/templates/README.md` | Template navigation index | Must expose task templates | Add task template group and derived links |
+| `memory-bank/README.md` | Root memory-bank index | Must expose optional `tasks/` destination | Add annotated `tasks/README.md` route |
+| `memory-bank/features/README.md` | Feature packages index | Must expose FT-012 docs package | Add annotated FT-012 link |
+| `scripts/check_memory_bank_index.py` | Link/reachability audit | Acceptance explicitly requires this check | Run as `CHK-01` |
+| `memory-bank/engineering/testing-policy.md` | Testing policy for docs changes | Sets manual-only and evidence expectations | Reuse docs/check evidence split |
+
+## Test Strategy
+
+| Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites / commands | Required CI suites / jobs | Manual-only gap / justification | Manual-only approval ref |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Link/index/frontmatter integrity | `REQ-01`..`REQ-04`, `CHK-01` | `scripts/check_memory_bank_index.py` exists | Run existing audit after docs changes | `python3 scripts/check_memory_bank_index.py` | Same command if CI runs it | none | none |
+| Whitespace/conflict markers | `EC-06`, `CHK-05` | Git diff check available | Run git diff audit | `git diff --check` | Same command if CI runs it | none | none |
+| Source-specific leakage | `REQ-05`, `CHK-03`, `INV-05` | No dedicated suite | Run deterministic `rg` scan for known source-specific terms | `rg -n "alfagen|mercury|TASK-3446|rate-daemon|SlotDiagnostics|PositionAware|production log storm" memory-bank` | none known | Manual reviewer must confirm any allowed matches are only FT-012 provenance | none |
+| Promotion trigger completeness | `REQ-06`, `CHK-04`, `CTR-02`, `INV-01` | No dedicated suite | Run text scan and manual review | `rg -n "workflow_profile|Promotion|promotion|contract_change|feature-package|epic-package|ADR" memory-bank/flows memory-bank/tasks` | none known | Manual reviewer validates semantics because text scan cannot prove correctness | none |
+
+## Open Questions / Ambiguities
+
+No unresolved blocking questions remain after `decision-log.md` entries `DL-001` and `DL-002`. New uncertainty that changes scope, selected design or evidence contract must stop execution and update the correct owner document first.
+
+## Environment Contract
+
+| Area | Contract | Used by | Failure symptom |
+| --- | --- | --- | --- |
+| setup | Local checkout at `feature/issue-12-compact-task-flow-bugfix-refactor-chore`; no app runtime required | `STEP-01`..`STEP-07` | Expected paths under `memory-bank/` are missing |
+| test | Documentation verification uses Python script, `rg` and `git diff --check` | `CHK-01`, `CHK-03`, `CHK-04`, `CHK-05` | Command unavailable or returns non-zero without captured evidence |
+| access / network / secrets | `gh` access was used only to read issue #12 and source docs; implementation should not require secrets | `STEP-01` | Need for private source data beyond listed docs means stop and human gate |
+
+## Preconditions
+
+| Precondition ID | Canonical ref | Required state | Used by steps | Blocks start |
+| --- | --- | --- | --- | --- |
+| `PRE-01` | `REQ-01`..`REQ-06` | `brief.md` is active and has Design Requirement Decision | `STEP-01`..`STEP-07` | yes |
+| `PRE-02` | `SD-01`..`SD-04` | `design.md` is active and source scope decisions are recorded | `STEP-02`..`STEP-06` | yes |
+| `PRE-03` | `CON-02` | `scripts/check_memory_bank_index.py` exists | `STEP-07` | yes |
+
+## Workstreams
+
+| Workstream | Implements | Result | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| `WS-1` | `REQ-01`, `SOL-01`, `SOL-02` | New task-flow, bugfix-flow and refactor-flow docs | agent | `PRE-01`, `PRE-02` |
+| `WS-2` | `REQ-02`, `REQ-03`, `SOL-03`, `SOL-04` | New task templates and `tasks/README.md` | agent | `WS-1` |
+| `WS-3` | `REQ-04`, `SOL-05`, `SD-01` | Updated routing/index docs | agent | `WS-1`, `WS-2` |
+| `WS-4` | `REQ-05`, `REQ-06`, `SOL-06`, `CTR-02`, `CTR-04` | Source sanitization and promotion trigger review | agent | `WS-1`, `WS-2`, `WS-3` |
+| `WS-5` | `CHK-01`..`CHK-05` | Verification evidence and final acceptance state | agent | `WS-1`..`WS-4` |
+
+## Approval Gates
+
+No risky, irreversible or external side-effect actions are planned. If implementation discovers a need to publish, push, alter GitHub issue state or import private source artifacts not listed in issue #12, create `AG-01` and stop for human approval.
+
+## Порядок работ
+
+| Step ID | Actor | Implements | Goal | Touchpoints | Artifact | Verifies | Evidence IDs | Check command / procedure | Blocked by | Needs approval | Escalate if |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `STEP-01` | agent | `REQ-01`, `SOL-01`, `SOL-02` | Add generic task-flow family docs | `memory-bank/flows/task-flow.md`, `bugfix-flow.md`, `refactor-flow.md` | governed flow docs | `CHK-02`, `CHK-04` | `EVID-02`, `EVID-04` | Manual review plus promotion scan | `PRE-01`, `PRE-02` | none | Source terms are needed to explain generic rules |
+| `STEP-02` | agent | `REQ-02`, `SOL-03` | Add task templates | `memory-bank/flows/templates/task/` | `package-README.md`, `bugfix.md`, `refactor.md` | `CHK-01`, `CHK-02`, `CHK-03` | `EVID-01`, `EVID-02`, `EVID-03` | Link audit and source scan | `STEP-01` | none | Templates need `design.md` or `implementation-plan.md` inside `TASK-XXX/` |
+| `STEP-03` | agent | `REQ-03`, `SOL-04`, `SD-04` | Add optional tasks destination index | `memory-bank/tasks/README.md` | tasks index | `CHK-01`, `CHK-03` | `EVID-01`, `EVID-03` | Link audit and source scan | `STEP-01` | none | Source example package seems required |
+| `STEP-04` | agent | `REQ-04`, `SOL-05`, `SD-01` | Update routing/indexes | `memory-bank/flows/workflows.md`, `flows/README.md`, `flows/templates/README.md`, `memory-bank/README.md`, related indexes | updated index/routing docs | `CHK-01`, `CHK-04` | `EVID-01`, `EVID-04` | Link audit and promotion scan | `STEP-01`..`STEP-03` | none | Update conflicts with `feature-flow.md` ownership |
+| `STEP-05` | agent | `REQ-05`, `SOL-06`, `CTR-04` | Remove source-specific leakage | all new/updated docs | sanitized docs | `CHK-03` | `EVID-03` | Source-specific `rg` scan | `STEP-01`..`STEP-04` | none | Any match outside FT-012 provenance remains |
+| `STEP-06` | agent | `REQ-06`, `CTR-02`, `INV-01` | Review promotion triggers across selector, flows and templates | `memory-bank/flows/**`, `memory-bank/tasks/README.md` | promotion trigger verdict | `CHK-04` | `EVID-04` | Text scan plus manual verdict | `STEP-01`..`STEP-04` | none | Compact path can still hide capability/contract/high-risk/design work |
+| `STEP-07` | agent | `EC-06` | Run final checks and capture evidence | `artifacts/ft-012/verify/**` | verification logs | `CHK-01`..`CHK-05` | `EVID-01`..`EVID-05` | Required commands from `brief.md` | `STEP-01`..`STEP-06` | none | Any required check fails |
+
+## Parallelizable Work
+
+- `PAR-01` `STEP-02` templates and `STEP-03` tasks index can be drafted in parallel after `STEP-01` establishes flow terminology.
+- `PAR-02` `STEP-04` index updates should wait for actual target file paths to avoid broken links.
+- `PAR-03` `STEP-05` and `STEP-06` can run as review passes after all docs exist.
+
+## Checkpoints
+
+| Checkpoint ID | Refs | Condition | Evidence IDs |
+| --- | --- | --- | --- |
+| `CP-01` | `STEP-01`, `STEP-02`, `STEP-03` | All new flow/template/task destination docs exist with frontmatter and no source examples | `EVID-02`, `EVID-03` |
+| `CP-02` | `STEP-04`, `CHK-01` | All new docs reachable through index navigation | `EVID-01` |
+| `CP-03` | `STEP-06`, `CHK-04` | Promotion triggers are present and consistent across selector, task-flow and profile templates | `EVID-04` |
+| `CP-04` | `STEP-07`, `CHK-01`..`CHK-05` | Required checks have evidence and no blocking failures | `EVID-01`..`EVID-05` |
+
+## Execution Risks
+
+| Risk ID | Risk | Impact | Mitigation | Trigger |
+| --- | --- | --- | --- | --- |
+| `ER-01` | Source docs contain useful but out-of-scope artifacts | Scope creep | Keep `SD-02`; create follow-up instead of importing | Need for `workflow-decision-log.md` or metrics becomes material |
+| `ER-02` | Link audit fails due new nested indexes | Feature cannot pass acceptance | Update parent indexes and annotations before completion | `CHK-01` non-zero |
+| `ER-03` | Promotion triggers appear in only one doc | Compact flow becomes inconsistent | Repeat trigger language in selector, family flow, profile flows and templates | `CHK-04` manual review finds a missing trigger |
+| `ER-04` | Sanitization scan matches FT-012 source provenance | False-positive review noise | Treat matches inside FT-012 docs as allowed provenance; target docs must remain clean | `CHK-03` finds matches |
+
+## Stop Conditions / Fallback
+
+| Stop ID | Related refs | Trigger | Immediate action | Safe fallback state |
+| --- | --- | --- | --- | --- |
+| `STOP-01` | `REQ-05`, `CTR-04`, `ER-01` | Implementation needs source project examples to be understandable | Stop and open human gate | Feature docs remain active; target docs not finalized |
+| `STOP-02` | `REQ-06`, `INV-01`, `FM-01` | Compact task flow cannot be made safe without broader workflow policy | Stop and update `brief.md`/`design.md` or escalate | No target docs shipped as accepted |
+| `STOP-03` | `CHK-01`, `CHK-05` | Required automated documentation checks fail and cannot be resolved locally | Stop with failing evidence | Package remains `planned` |
+
+## Plan-local Evidence
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checkpoints |
+| --- | --- | --- | --- | --- |
+| `EVID-09` | Review-improve cycle summary for feature docs | agent | Final response and/or `decision-log.md` entries | `CP-04` |
+
+## Готово для приемки
+
+- Все workstreams завершены или явно остановлены через `STOP-*`.
+- Все checkpoints имеют evidence.
+- Required local suites from `brief.md` are green, and CI is not known to contradict local verify.
+- Manual-only gaps are limited to reviewer semantic verdicts already named in `CHK-02` and `CHK-04`.
+- Support docs do not conflict with canonical `brief.md`, `design.md` or this plan.
+- Финальная приемка идёт по `brief.md` `Verify`, а не по этому checklist.
+
+## Completion Notes
+
+- `WS-1` done: added `task-flow.md`, `bugfix-flow.md`, `refactor-flow.md`.
+- `WS-2` done: added task templates and `memory-bank/tasks/README.md`.
+- `WS-3` done: updated routing/index docs.
+- `WS-4` done: source sanitization and promotion trigger review passed.
+- `WS-5` done: evidence captured under `artifacts/ft-012/verify/`.

--- a/memory-bank/features/README.md
+++ b/memory-bank/features/README.md
@@ -29,3 +29,9 @@ audience: humans_and_agents
 - Базовый формат: `FT-XXX/`
 - Вместо `XXX` используй идентификатор, принятый в проекте: issue id, ticket id или другой стабильный ключ
 - Один package = одна delivery-единица
+
+## Packages
+
+- [`FT-012`](FT-012/)
+  Читать, когда нужно: вести delivery по issue #12 о compact task-flow для bugfix/refactor/chore через `feature-flow`.
+  Отвечает на вопрос: какие scope, design, plan и локальные решения управляют добавлением task-flow family.

--- a/memory-bank/flows/README.md
+++ b/memory-bank/flows/README.md
@@ -2,9 +2,12 @@
 title: Flows And Templates Index
 doc_kind: governance
 doc_function: index
-purpose: Навигация по lifecycle flows и governed-шаблонам. Читать при создании epic или feature package, переводе инициативы между стадиями или инстанцировании нового governed-документа.
+purpose: Навигация по lifecycle flows и governed-шаблонам. Читать при создании task, epic или feature package, переводе инициативы между стадиями или инстанцировании нового governed-документа.
 derived_from:
   - ../dna/governance.md
+  - task-flow.md
+  - bugfix-flow.md
+  - refactor-flow.md
   - epic-flow.md
   - feature-flow.md
   - workflows.md
@@ -15,9 +18,12 @@ audience: humans_and_agents
 
 # Flows And Templates Index
 
-Каталог `memory-bank/flows/` содержит reusable process-layer для шаблона: lifecycle rules, taxonomy стабильных идентификаторов и governed templates.
+Каталог `memory-bank/flows/` содержит reusable process-layer для шаблона: task/feature/epic lifecycle rules, taxonomy стабильных идентификаторов и governed templates.
 
 - [Task Workflows](workflows.md) — маршрутизация задач по типам, базовый цикл разработки и градиент автономии.
+- [Task Flow](task-flow.md) — compact/managed non-feature lifecycle для `tracker-only`, bugfix/refactor/chore profiles и `TASK-XXX` packages.
+- [Bugfix Flow](bugfix-flow.md) — профильный процесс symptom/reproduction/root cause/fix boundary/regression evidence для compact bugfix задач.
+- [Refactor Flow](refactor-flow.md) — профильный процесс intent/invariants/change surface/checkpoints/verification для refactor/chore задач без изменения поведения.
 - [Epic Flow](epic-flow.md) — lifecycle крупных инициатив, roadmap, decision log, risks и handoff в feature packages.
 - [Feature Flow](feature-flow.md) — lifecycle `brief.md -> optional design.md -> implementation-plan.md`, gates и стабильные ID (`REQ-*`, `SOL-*`, `STEP-*`).
-- [Templates Index](templates/README.md) — эталонные шаблоны governed-документов, включая PRD, use case, epic, feature и ADR.
+- [Templates Index](templates/README.md) — эталонные шаблоны governed-документов, включая task, PRD, use case, epic, feature и ADR.

--- a/memory-bank/flows/bugfix-flow.md
+++ b/memory-bank/flows/bugfix-flow.md
@@ -1,0 +1,106 @@
+---
+title: Bugfix Flow
+doc_kind: governance
+doc_function: canonical
+purpose: "Определяет процесс, gates переходов и evidence contract для bugfix-compact и managed bugfix задач."
+derived_from:
+  - ../dna/governance.md
+  - workflows.md
+  - task-flow.md
+canonical_for:
+  - bugfix_task_process
+  - bugfix_root_cause_gate
+  - bugfix_regression_evidence_rules
+  - bugfix_identifier_taxonomy
+status: active
+audience: humans_and_agents
+---
+
+# Bugfix Flow
+
+`bugfix-flow` применяется после selector-а из [`workflows.md`](workflows.md), когда выбран:
+
+- `workflow_profile=bugfix-compact`;
+- `workflow_profile=managed-task` и primary owner task package - `bugfix.md`.
+
+Общие правила carrier/package, worktree, promotion и closure задает [`task-flow.md`](task-flow.md). Этот документ владеет только bugfix-процессом: symptom, reproduction, root cause, fix boundary и regression coverage.
+
+## Комплект Документов
+
+| Profile | Carrier | Когда достаточно |
+| --- | --- | --- |
+| `bugfix-compact` | GitHub issue/PR note по [`templates/task/bugfix.md`](templates/task/bugfix.md) | Дефект локален, root cause понятен, fix boundary помещается в PR/issue |
+| managed bugfix | `memory-bank/tasks/TASK-XXX/README.md` + `bugfix.md` | Нужен durable context, но нет feature capability или contract/design trigger-а |
+
+`bugfix.md` не должен содержать feature scope, design alternatives, rollout/backout design или implementation plan. Если это нужно, task повышается по [`workflows.md`](workflows.md).
+
+## Процесс
+
+```text
+report -> symptom -> reproduction/evidence -> root cause -> fix boundary -> regression coverage -> scoped fix -> evidence
+```
+
+1. Зафиксируй observable symptom.
+2. Зафиксируй reproduction или evidence source.
+3. Найди root cause и запиши его как `RC-*`.
+4. Определи fix boundary и non-scope.
+5. Определи regression coverage до behavior-changing fix.
+6. Реализуй scoped fix.
+7. Заполни evidence carrier в issue/PR или `bugfix.md`.
+
+## Gates Переходов
+
+### Routing -> Bugfix Ready
+
+- [ ] Routing Signature заполнен.
+- [ ] `kind=bugfix`.
+- [ ] `contract_change=none` для `bugfix-compact`.
+- [ ] `risk` не `high/critical` для `bugfix-compact`.
+- [ ] Promotion triggers из [`workflows.md`](workflows.md) проверены.
+- [ ] Выбран carrier: issue/PR note или managed `TASK-XXX/README.md` + `bugfix.md`.
+
+### Bugfix Ready -> Fix Ready
+
+- [ ] `SYM-*` описывает, что сломано, где наблюдается и кто/что затронуто.
+- [ ] `REPRO-*` содержит минимальное воспроизведение или ссылку на evidence.
+- [ ] `RC-*` содержит проверяемую причину дефекта.
+- [ ] `FIX-*` описывает минимальный fix boundary.
+- [ ] `NS-*` фиксирует, что не меняется.
+- [ ] `CHK-*` / `EVID-*` покрывают regression path.
+
+Если root cause неизвестен, разрешены только discovery, logging, reproduction spec или diagnostic capture. Behavior-changing fix ждет известного `RC-*` или promotion.
+
+### Fix Ready -> Execution
+
+- [ ] Change surface не выходит за `FIX-*`.
+- [ ] Выбранные проверки соответствуют `AGENTS.md` и [`../engineering/testing-policy.md`](../engineering/testing-policy.md).
+- [ ] Manual-only verification имеет причину, процедуру и approval ref.
+- [ ] Financial/security bugfix имеет automated regression coverage или approved manual-only exception с причиной.
+
+### Execution -> Done
+
+- [ ] Symptom больше не воспроизводится.
+- [ ] Regression coverage выполнен или documented manual-only exception approved.
+- [ ] Evidence carrier заполнен.
+- [ ] Если в ходе fix появился contract/design/capability trigger, task promoted или явно остановлен.
+
+## Стабильные Идентификаторы
+
+| Prefix | Значение | Где используется |
+| --- | --- | --- |
+| `SYM-*` | наблюдаемый symptom | `bugfix.md`, issue/PR |
+| `REPRO-*` | шаг воспроизведения или evidence source | `bugfix.md`, issue/PR |
+| `RC-*` | root cause | `bugfix.md`, issue/PR |
+| `FIX-*` | граница fix-а | `bugfix.md`, issue/PR |
+| `NS-*` | non-scope | `bugfix.md`, issue/PR |
+| `CHK-*` | executable/manual check | `bugfix.md`, issue/PR |
+| `EVID-*` | evidence carrier | `bugfix.md`, issue/PR |
+| `AG-*` | approval gate | `bugfix.md`, issue/PR |
+
+## Правила Границ
+
+1. Bugfix устраняет дефект, а не создает новую capability.
+2. Fix boundary должен быть меньше или равен root cause boundary. Если fix требует wider redesign, task повышается.
+3. Bugfix не меняет API/schema/security/financial/integration/rollout contract в compact profile.
+4. Regression coverage обязателен для behavior-changing fix.
+5. Если исправление создает новый устойчивый scenario, это feature work.

--- a/memory-bank/flows/refactor-flow.md
+++ b/memory-bank/flows/refactor-flow.md
@@ -1,0 +1,105 @@
+---
+title: Refactor Flow
+doc_kind: governance
+doc_function: canonical
+purpose: "Определяет процесс, gates переходов и evidence contract для refactor-small и managed refactor/chore задач."
+derived_from:
+  - ../dna/governance.md
+  - workflows.md
+  - task-flow.md
+canonical_for:
+  - refactor_task_process
+  - refactor_invariant_gate
+  - refactor_checkpoint_rules
+  - refactor_identifier_taxonomy
+status: active
+audience: humans_and_agents
+---
+
+# Refactor Flow
+
+`refactor-flow` применяется после selector-а из [`workflows.md`](workflows.md), когда выбран:
+
+- `workflow_profile=refactor-small`;
+- `workflow_profile=managed-task` и primary owner task package - `refactor.md`.
+
+Общие правила carrier/package, worktree, promotion и closure задает [`task-flow.md`](task-flow.md). Этот документ владеет только refactor/chore-процессом: intent, behavior invariants, change surface, checkpoints и verification.
+
+## Комплект Документов
+
+| Profile | Carrier | Когда достаточно |
+| --- | --- | --- |
+| `refactor-small` | GitHub issue/PR note по [`templates/task/refactor.md`](templates/task/refactor.md) | Observable behavior не меняется, invariants и verification помещаются в issue/PR |
+| managed refactor/chore | `memory-bank/tasks/TASK-XXX/README.md` + `refactor.md` | Нужен durable context, checkpoints или wider technical scope, но нет feature capability или contract/design trigger-а |
+
+`refactor.md` не должен содержать new runtime behavior, feature scope, rollout/backout design или implementation plan. Если это нужно, task повышается по [`workflows.md`](workflows.md).
+
+## Процесс
+
+```text
+intent -> behavior invariants -> change surface -> checkpoints -> scoped refactor -> verification evidence
+```
+
+1. Зафиксируй technical intent.
+2. Зафиксируй behavior invariants.
+3. Определи change surface и non-scope.
+4. Определи checkpoints и stop conditions.
+5. Реализуй scoped refactor без intentional behavior change.
+6. Заполни verification/evidence carrier в issue/PR или `refactor.md`.
+
+## Gates Переходов
+
+### Routing -> Refactor Ready
+
+- [ ] Routing Signature заполнен.
+- [ ] `kind=refactor` или `kind=chore`.
+- [ ] `contract_change=none` для `refactor-small`.
+- [ ] `risk` не `high/critical` для `refactor-small`.
+- [ ] Promotion triggers из [`workflows.md`](workflows.md) проверены.
+- [ ] Выбран carrier: issue/PR note или managed `TASK-XXX/README.md` + `refactor.md`.
+
+### Refactor Ready -> Execution Ready
+
+- [ ] `INT-*` фиксирует technical intent.
+- [ ] `INV-*` фиксирует observable behavior и public contracts, которые должны сохраниться.
+- [ ] `SURF-*` фиксирует affected modules/paths.
+- [ ] `NS-*` фиксирует, что не входит в refactor.
+- [ ] `CP-*` задает checkpoints или stop conditions.
+- [ ] `CHK-*` / `EVID-*` покрывают invariants.
+
+Если проверяемые invariants нельзя сформулировать, refactor не готов к execution: сначала нужен discovery или promotion.
+
+### Execution Ready -> Execution
+
+- [ ] Change surface не выходит за `SURF-*`.
+- [ ] Нет intentional observable behavior change.
+- [ ] Выбранные проверки соответствуют `AGENTS.md` и [`../engineering/testing-policy.md`](../engineering/testing-policy.md).
+- [ ] Manual-only verification имеет причину, процедуру и approval ref.
+
+### Execution -> Done
+
+- [ ] `INV-*` подтверждены проверками или approved manual evidence.
+- [ ] Checkpoints закрыты или оставлены как explicit follow-up.
+- [ ] Evidence carrier заполнен.
+- [ ] Если behavior change стал нужным или неизбежным, task promoted или явно остановлен.
+
+## Стабильные Идентификаторы
+
+| Prefix | Значение | Где используется |
+| --- | --- | --- |
+| `INT-*` | intent refactor/chore | `refactor.md`, issue/PR |
+| `INV-*` | invariant поведения | `refactor.md`, issue/PR |
+| `SURF-*` | change surface | `refactor.md`, issue/PR |
+| `NS-*` | non-scope | `refactor.md`, issue/PR |
+| `CP-*` | checkpoint или stop condition | `refactor.md`, issue/PR |
+| `CHK-*` | executable/manual check | `refactor.md`, issue/PR |
+| `EVID-*` | evidence carrier | `refactor.md`, issue/PR |
+| `AG-*` | approval gate | `refactor.md`, issue/PR |
+
+## Правила Границ
+
+1. Refactor/chore не меняет observable behavior.
+2. Если behavior change желателен или необходим, task повышается до `feature-package` или другого подходящего profile.
+3. Refactor не меняет API/schema/security/financial/integration/rollout contract в compact profile.
+4. Checkpoints должны помогать остановить работу до behavior drift, а не заменять tests/evidence.
+5. Системный refactor с несколькими independent delivery units повышается минимум до `managed-task`, часто до `epic-package`.

--- a/memory-bank/flows/task-flow.md
+++ b/memory-bank/flows/task-flow.md
@@ -1,0 +1,176 @@
+---
+title: Task Flow
+doc_kind: governance
+doc_function: canonical
+purpose: "Определяет общий lifecycle, document profiles и package rules для compact/managed non-feature задач."
+derived_from:
+  - ../dna/governance.md
+  - workflows.md
+  - bugfix-flow.md
+  - refactor-flow.md
+canonical_for:
+  - task_flow_family_routing
+  - compact_task_document_profiles
+  - managed_task_directory_structure
+  - task_flow_stages
+  - task_transition_gates
+  - task_evidence_rules
+status: active
+audience: humans_and_agents
+---
+
+# Task Flow
+
+`task-flow` применяется после selector-а из [`workflows.md`](workflows.md), когда выбран один из non-feature profiles:
+
+- `tracker-only`
+- `bugfix-compact`
+- `refactor-small`
+- `managed-task`
+
+Этот flow не заменяет [`bugfix-flow.md`](bugfix-flow.md), [`refactor-flow.md`](refactor-flow.md), [`feature-flow.md`](feature-flow.md) или [`epic-flow.md`](epic-flow.md). Он задает общий lifecycle и правила carrier/package для non-feature задач; bugfix-процесс живет в `bugfix-flow`, refactor/chore-процесс - в `refactor-flow`.
+
+Если задача создает новую capability, меняет устойчивый scenario, затрагивает API/schema/security/financial/integration/rollout contract или требует design reasoning, ее нужно повысить до `feature-package`, ADR или `epic-package` по promotion rules.
+
+## Комплекты Документов Профилей
+
+| Profile | Обязательные carriers | Опциональные carriers | Когда достаточно |
+| --- | --- | --- | --- |
+| `tracker-only` | GitHub issue/PR с Routing Signature, boundary и verification evidence | none | `tiny/small`, `low` risk, без contract change, без durable owner doc |
+| `bugfix-compact` | GitHub issue/PR note по [`templates/task/bugfix.md`](templates/task/bugfix.md), процесс по [`bugfix-flow.md`](bugfix-flow.md) | `memory-bank/tasks/TASK-XXX/README.md` + `bugfix.md` | Дефект локален, root cause понятен, fix boundary и regression coverage помещаются в compact carrier |
+| `refactor-small` | GitHub issue/PR note по [`templates/task/refactor.md`](templates/task/refactor.md), процесс по [`refactor-flow.md`](refactor-flow.md) | `memory-bank/tasks/TASK-XXX/README.md` + `refactor.md` | Observable behavior не меняется, invariants и verification помещаются в compact carrier |
+| `managed-task` | `memory-bank/tasks/TASK-XXX/README.md` + `bugfix.md` или `refactor.md` | linked ADR/runbook/incident docs, evidence artifacts | Issue/PR carrier недостаточен, но full feature package не нужен |
+
+`README.md` обязателен только для durable `memory-bank/tasks/TASK-XXX/` package. Для issue/PR-only profiles routing layer живет в issue/PR body или PR comment.
+
+## Семейство Процессов
+
+### `tracker-only`
+
+```text
+task/request -> routing signature -> scoped change -> focused verification -> PR/issue evidence
+```
+
+Используй для минимальных задач, где отдельный owner doc не нужен. Обязательные элементы процесса: зафиксировать boundary, выполнить проверку, оставить evidence в issue/PR.
+
+### `bugfix-compact`
+
+Используй [`bugfix-flow.md`](bugfix-flow.md). `task-flow` владеет carrier/package и promotion, `bugfix-flow` владеет symptom, reproduction, root cause, fix boundary и regression coverage.
+
+### `refactor-small`
+
+Используй [`refactor-flow.md`](refactor-flow.md). `task-flow` владеет carrier/package и promotion, `refactor-flow` владеет intent, behavior invariants, change surface, checkpoints и verification.
+
+### `managed-task`
+
+```text
+routing -> TASK-XXX package -> primary owner doc -> checkpoints -> execution -> evidence -> package/PR closure
+```
+
+Используй, когда issue/PR carrier уже недостаточен, но feature package еще не нужен. Минимальный комплект: `README.md` + ровно один primary owner (`bugfix.md` или `refactor.md`). Все gates ниже применяются к package как к durable carrier.
+
+## Правила Package
+
+1. Durable non-feature package живет в `memory-bank/tasks/TASK-XXX/`.
+2. `README.md` - routing/index layer package-а. Создается по [`templates/task/package-README.md`](templates/task/package-README.md).
+3. `bugfix.md` - canonical owner compact bugfix-а по [`bugfix-flow.md`](bugfix-flow.md): symptom, reproduction, root cause, fix boundary, regression coverage.
+4. `refactor.md` - canonical owner compact refactor/chore по [`refactor-flow.md`](refactor-flow.md): intent, behavior invariants, change surface, checkpoints, verification.
+5. В одном `TASK-XXX/` должен быть ровно один primary task owner: `bugfix.md` или `refactor.md`, кроме случаев, когда package явно служит routing-index для нескольких follow-up tasks. Если появляется несколько independent delivery units, создай отдельные `TASK-*` или promote в `epic-package`.
+6. `implementation-plan.md` внутри `TASK-XXX/` не создается. Sequencing и checkpoints должны помещаться в primary task owner. Если нужен полноценный execution contract, promote до `feature-package` или создай отдельный approved plan по upstream owner-решению.
+7. `design.md` внутри `TASK-XXX/` не создается. Если нужен solution-space owner, alternatives/trade-off reasoning, C4, migration strategy или rollout/backout design, promote до `feature-package` или ADR + feature package.
+8. Все owner-документы task package пишутся на русском языке; identifiers, paths, class/API names и внешние product names сохраняются как есть.
+9. При создании durable `TASK-XXX/` добавь ссылку из исходного issue/PR на package docs.
+
+## Жизненный Цикл
+
+```mermaid
+flowchart LR
+    RT["Routing<br/>Routing Signature + profile"] --> TR["Task Ready<br/>carrier/package has problem boundary"]
+    TR --> ER["Execution Ready<br/>checks/evidence defined"]
+    ER --> EX["Execution<br/>scoped code/docs changes"]
+    EX --> DN["Done<br/>verification evidence captured"]
+    RT --> PR["Promoted<br/>feature/epic/ADR/incident flow"]
+    TR --> PR
+    ER --> PR
+    EX --> PR
+    RT --> CL["Cancelled"]
+    TR --> CL
+    ER --> CL
+    EX --> CL
+```
+
+## Gates Переходов
+
+### Routing -> Task Ready
+
+- [ ] Routing Signature заполнен, включая `workflow_profile`.
+- [ ] Promotion triggers из [`workflows.md`](workflows.md) проверены.
+- [ ] Для compact profiles нет `risk=high/critical`.
+- [ ] `contract_change=none` для `tracker-only`, `bugfix-compact`, `refactor-small`.
+- [ ] Issue/PR carrier или `TASK-XXX/README.md` содержит ссылку на выбранный profile.
+- [ ] Если есть `unknown` в `kind`, `risk`, `change_surface` или `contract_change`, задача не переходит в Task Ready без discovery или promotion.
+
+### Task Ready -> Execution Ready
+
+Для `bugfix-compact` / managed bugfix:
+
+- [ ] Profile gates из [`bugfix-flow.md`](bugfix-flow.md) выполнены.
+
+Для `refactor-small` / managed refactor:
+
+- [ ] Profile gates из [`refactor-flow.md`](refactor-flow.md) выполнены.
+
+Для `tracker-only`:
+
+- [ ] Issue/PR carrier содержит краткий rationale, boundary, verification и evidence target.
+
+### Execution Ready -> Execution
+
+- [ ] Выбран worktree/branch по project git rules.
+- [ ] Required docs/carriers созданы или явно не нужны для выбранного profile.
+- [ ] Approval gates для risky/manual-only actions зафиксированы через `AG-*` или issue/PR comment.
+- [ ] Test/verification commands соответствуют `AGENTS.md` и [`../engineering/testing-policy.md`](../engineering/testing-policy.md).
+
+### Execution -> Done
+
+- [ ] Code/docs changes не выходят за выбранный task boundary.
+- [ ] Regression/focused verification выполнена или documented manual-only exception approved.
+- [ ] Evidence carrier заполнен.
+- [ ] PR/issue содержит routing signature или ссылку на durable task package.
+- [ ] Если появились promotion triggers, они не замаскированы: задача promoted или явно остановлена.
+- [ ] Для durable `TASK-XXX/` `delivery_status` обновлен до `done` или package оставлен с явным follow-up status.
+
+### -> Promoted
+
+Promotion обязателен, если появился любой trigger:
+
+- новая или materially changed user/operator/system capability;
+- API/event/schema/file format/CLI/security/financial/integration/rollout change;
+- solution-space reasoning, ADR dependency, C4, migration strategy, rollout/backout или failure-mode design;
+- high/critical risk;
+- несколько independent delivery units;
+- repeated review findings показывают, что проблема находится upstream.
+
+## Общие Стабильные Идентификаторы
+
+| Prefix | Значение | Где используется |
+| --- | --- | --- |
+| `ROUTE-*` | routing-решение или заметка выбора profile | issue/PR, `README.md` |
+| `NS-*` | non-scope | `bugfix.md`, `refactor.md` |
+| `CHK-*` | executable/manual check | `bugfix.md`, `refactor.md`, issue/PR |
+| `EVID-*` | evidence carrier | `bugfix.md`, `refactor.md`, issue/PR |
+| `OQ-*` | открытый вопрос | любой task carrier |
+| `AG-*` | approval gate | managed package, issue/PR |
+
+Bugfix identifiers (`SYM-*`, `REPRO-*`, `RC-*`, `FIX-*`) определены в [`bugfix-flow.md`](bugfix-flow.md). Refactor identifiers (`INT-*`, `INV-*`, `SURF-*`, `CP-*`) определены в [`refactor-flow.md`](refactor-flow.md).
+
+## Правила Границ
+
+1. Task flow владеет локальными non-feature работами. Он не должен становиться скрытым feature package.
+2. Issue/PR-only profiles все равно требуют evidence. "No docs" не означает "no routing".
+3. Durable `TASK-XXX/` package существует только когда issue/PR carrier недостаточен.
+4. `TASK-XXX/` package не владеет architecture design. Если нужен design, task нужно повысить.
+5. Bugfix-правила root cause, behavior-changing fix и regression coverage задает [`bugfix-flow.md`](bugfix-flow.md).
+6. Refactor-правила invariants, checkpoints и запрета observable behavior change задает [`refactor-flow.md`](refactor-flow.md).
+7. Manual-only verification должен включать причину, процедуру и approval ref.
+8. Financial/security bugfixes требуют automated regression coverage, кроме явно approved manual-only исключения с причиной; иначе task нужно повысить.

--- a/memory-bank/flows/templates/README.md
+++ b/memory-bank/flows/templates/README.md
@@ -2,7 +2,7 @@
 title: Templates Index
 doc_kind: governance
 doc_function: index
-purpose: Навигация по эталонным шаблонам документации проекта. Читать, чтобы завести PRD, use case, epic, фичу, ADR, prompt или execution-документ без изобретения новой структуры.
+purpose: Навигация по эталонным шаблонам документации проекта. Читать, чтобы завести task package, PRD, use case, epic, фичу, ADR, prompt или execution-документ без изобретения новой структуры.
 derived_from:
   - ../../dna/governance.md
   - prd/PRD-XXX.md
@@ -13,6 +13,9 @@ derived_from:
   - epic/decision-log.md
   - epic/subissues.md
   - epic/risks.md
+  - task/package-README.md
+  - task/bugfix.md
+  - task/refactor.md
   - feature/README.md
   - feature/brief.md
   - feature/design.md
@@ -42,6 +45,9 @@ audience: humans_and_agents
 - [EP-XXX: Decision Log Template](epic/decision-log.md) — local epic decisions that do not require global ADR.
 - [EP-XXX: Subissues Template](epic/subissues.md) — candidate/accepted delivery subissue registry.
 - [EP-XXX: Risks Template](epic/risks.md) — epic-level risk register.
+- [TASK-XXX README Template](task/package-README.md) — routing/index layer для durable managed non-feature task package.
+- [TASK-XXX Bugfix Template](task/bugfix.md) — compact bugfix note для symptom, reproduction, root cause, fix boundary и regression evidence.
+- [TASK-XXX Refactor Template](task/refactor.md) — compact refactor/chore note для intent, invariants, change surface, checkpoints и verification.
 - [FT-XXX Feature README Template](feature/README.md) — шаблон README для feature-каталога. Отвечает на вопрос: как оформить feature-level index.
 - [FT-XXX: Brief Template](feature/brief.md) — canonical problem-space template для новых feature packages. Отвечает на вопрос: как зафиксировать intent, scope и verify contract без solution/execution деталей.
 - [FT-XXX: Design Template](feature/design.md) — canonical solution-space template для feature package. Отвечает на вопрос: как зафиксировать selected design, rationale, contracts, failure modes и design-pack routing.

--- a/memory-bank/flows/templates/task/bugfix.md
+++ b/memory-bank/flows/templates/task/bugfix.md
@@ -1,0 +1,88 @@
+---
+title: TASK-XXX Bugfix Template
+doc_kind: task
+doc_function: template
+purpose: "Compact template для bugfix profile: фиксирует symptom, reproduction, root cause, fix boundary и regression evidence без full feature package."
+derived_from:
+  - ../../workflows.md
+  - ../../task-flow.md
+  - ../../bugfix-flow.md
+  - ../../../dna/frontmatter.md
+status: active
+audience: humans_and_agents
+template_for: bugfix_task
+template_target_path: ../../../tasks/TASK-XXX/bugfix.md
+---
+
+# TASK-XXX: Bugfix Name
+
+Этот template можно использовать в двух режимах:
+
+- как секцию GitHub issue/PR body для `bugfix-compact`;
+- как `memory-bank/tasks/TASK-XXX/bugfix.md`, если нужен durable managed-task package.
+
+## Instantiated Frontmatter
+
+```yaml
+title: "TASK-XXX: Bugfix Name"
+doc_kind: task
+doc_function: canonical
+purpose: "Compact bugfix note: symptom, reproduction, root cause, fix boundary and regression evidence."
+derived_from:
+  - ../../flows/workflows.md
+  - ../../flows/task-flow.md
+  - ../../flows/bugfix-flow.md
+status: active
+delivery_status: planned
+audience: humans_and_agents
+workflow_profile: bugfix-compact
+must_not_define:
+  - feature_scope
+  - architecture_decision
+```
+
+## Instantiated Body
+
+```markdown
+# TASK-XXX: Bugfix Name
+
+## Routing
+
+| Field | Value |
+| --- | --- |
+| `kind` | `bugfix` |
+| `size` | `tiny` / `small` / `medium` |
+| `risk` | `low` / `normal` / `high` |
+| `change_surface` | `single_component` / `multi_component` / `cross_boundary` |
+| `contract_change` | `none` |
+| `workflow_profile` | `bugfix-compact` |
+
+Promotion check: если `contract_change != none`, `risk=high/critical` или root cause требует design reasoning, остановиться и поднять profile по `workflows.md`.
+
+## Symptom
+
+- Что сломано:
+- Где наблюдается:
+- Кто/что затронуто:
+
+## Reproduction
+
+- `REPRO-01` Минимальный способ воспроизвести дефект или ссылка на evidence.
+
+## Root Cause
+
+- `RC-01` Проверяемая причина дефекта.
+
+## Fix Boundary
+
+- `FIX-01` Что меняем.
+- `NS-01` Что не меняем.
+
+## Regression Coverage
+
+| Check ID | Covers | How to check | Expected result | Evidence |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `REPRO-01`, `RC-01`, `FIX-01` | focused spec / manual procedure | Дефект не воспроизводится, happy path сохранен | PR checks / CI / attached log |
+
+Manual-only exception допустим только с причиной, процедурой и approval ref.
+```

--- a/memory-bank/flows/templates/task/package-README.md
+++ b/memory-bank/flows/templates/task/package-README.md
@@ -1,0 +1,71 @@
+---
+title: TASK-XXX README Template
+doc_kind: task
+doc_function: template
+purpose: "Шаблон routing/index layer для durable managed task package в memory-bank/tasks/TASK-XXX/."
+derived_from:
+  - ../../task-flow.md
+  - ../../bugfix-flow.md
+  - ../../refactor-flow.md
+  - ../../../dna/frontmatter.md
+status: active
+audience: humans_and_agents
+template_for: managed_task_readme
+template_target_path: ../../../tasks/TASK-XXX/README.md
+---
+
+# TASK-XXX: Managed Task Package
+
+Этот template используется только для durable `memory-bank/tasks/TASK-XXX/` package. Для issue/PR-only compact profiles `README.md` не нужен.
+
+## Инстанцированный Frontmatter
+
+```yaml
+title: "TASK-XXX: Task Package"
+doc_kind: task
+doc_function: index
+purpose: "Routing/index layer для managed non-feature task package."
+derived_from:
+  - ../../flows/task-flow.md
+status: active
+delivery_status: planned
+audience: humans_and_agents
+workflow_profile: managed-task
+```
+
+## Инстанцированное Тело
+
+```markdown
+# TASK-XXX: Task Package
+
+## Маршрутизация
+
+| Field | Value |
+| --- | --- |
+| `kind` | `bugfix` / `refactor` / `chore` |
+| `size` | `small` / `medium` |
+| `risk` | `low` / `normal` |
+| `change_surface` | `single_component` / `multi_component` |
+| `contract_change` | `none` |
+| `workflow_profile` | `managed-task` |
+
+Promotion check: если появляется capability, contract change, high/critical risk, design reasoning или несколько delivery units, остановиться и поднять profile по `workflows.md`.
+
+## Аннотированный индекс
+
+Оставь только route для primary owner этого package. В одном обычном `TASK-XXX/` должен быть `bugfix.md` или `refactor.md`, но не оба сразу.
+
+- [`bugfix.md`](bugfix.md)
+  Читать, когда package является managed bugfix.
+  Отвечает на вопрос: какой symptom/root cause/fix boundary и regression coverage действуют.
+
+- [`refactor.md`](refactor.md)
+  Читать, когда package является managed refactor/chore.
+  Отвечает на вопрос: какой intent, behavior invariants, change surface и verification действуют.
+
+## Ссылки
+
+- GitHub issue:
+- PR:
+- Related incident/ADR/runbook:
+```

--- a/memory-bank/flows/templates/task/refactor.md
+++ b/memory-bank/flows/templates/task/refactor.md
@@ -1,0 +1,87 @@
+---
+title: TASK-XXX Refactor Template
+doc_kind: task
+doc_function: template
+purpose: "Compact template для refactor/chore profile: фиксирует intent, behavior invariants, change surface, checkpoints и verification без full feature package."
+derived_from:
+  - ../../workflows.md
+  - ../../task-flow.md
+  - ../../refactor-flow.md
+  - ../../../dna/frontmatter.md
+status: active
+audience: humans_and_agents
+template_for: refactor_task
+template_target_path: ../../../tasks/TASK-XXX/refactor.md
+---
+
+# TASK-XXX: Refactor Name
+
+Этот template можно использовать в двух режимах:
+
+- как секцию GitHub issue/PR body для `refactor-small`;
+- как `memory-bank/tasks/TASK-XXX/refactor.md`, если нужен durable managed-task package.
+
+## Instantiated Frontmatter
+
+```yaml
+title: "TASK-XXX: Refactor Name"
+doc_kind: task
+doc_function: canonical
+purpose: "Compact refactor/chore note: intent, invariants, change surface, checkpoints and verification."
+derived_from:
+  - ../../flows/workflows.md
+  - ../../flows/task-flow.md
+  - ../../flows/refactor-flow.md
+status: active
+delivery_status: planned
+audience: humans_and_agents
+workflow_profile: refactor-small
+must_not_define:
+  - feature_scope
+  - new_runtime_behavior
+```
+
+## Instantiated Body
+
+```markdown
+# TASK-XXX: Refactor Name
+
+## Routing
+
+| Field | Value |
+| --- | --- |
+| `kind` | `refactor` / `chore` |
+| `size` | `tiny` / `small` / `medium` |
+| `risk` | `low` / `normal` / `high` |
+| `change_surface` | `single_component` / `multi_component` / `cross_boundary` |
+| `contract_change` | `none` |
+| `workflow_profile` | `refactor-small` / `managed-task` |
+
+Promotion check: если меняется observable behavior, contract, rollout, security/financial boundary или несколько bounded contexts, поднять profile по `workflows.md`.
+
+## Intent
+
+- `INT-01` Какую техническую проблему устраняем.
+
+## Behavior Invariants
+
+- `INV-01` Какое observable behavior должно остаться неизменным.
+- `INV-02` Какие публичные contracts не должны измениться.
+
+## Change Surface
+
+- `SURF-01` Затронутые модули/paths.
+- `NS-01` Что явно не входит в refactor.
+
+## Checkpoints
+
+| Checkpoint ID | Purpose | Evidence |
+| --- | --- | --- |
+| `CP-01` | Сохранить поведение до/после refactor | focused specs / CI / diff review |
+
+## Verification
+
+| Check ID | Covers | How to check | Expected result | Evidence |
+| --- | --- | --- | --- | --- |
+| `CHK-01` | `INV-01`, `INV-02` | focused specs / existing suite / static scan | Поведение и contracts сохранены | PR checks / CI / attached log |
+```

--- a/memory-bank/flows/workflows.md
+++ b/memory-bank/flows/workflows.md
@@ -5,17 +5,25 @@ doc_function: canonical
 purpose: Маршрутизация задач по типам и базовый цикл разработки. Читать при получении новой задачи для выбора подхода.
 derived_from:
   - ../dna/governance.md
+  - task-flow.md
+  - bugfix-flow.md
+  - refactor-flow.md
   - feature-flow.md
 canonical_for:
   - task_routing_rules
+  - task_signature_routing_rules
   - base_development_cycle
   - workflow_type_selection
+  - workflow_document_profile_selection
+  - workflow_promotion_rules
   - autonomy_gradient
 status: active
 audience: humans_and_agents
 ---
 
 # Task Workflows
+
+Этот документ является верхним selector-слоем перед `task-flow`, `bugfix-flow`, `refactor-flow`, `feature-flow` и `epic-flow`. Агент сначала классифицирует задачу и выбирает минимальный workflow/document profile, а уже затем применяет конкретный flow.
 
 ## Базовый цикл
 
@@ -27,7 +35,7 @@ audience: humans_and_agents
                   → Принят
 ```
 
-Артефакт — то, что создаётся на каждом этапе: brief, design-док, план, код, PR, runbook.
+Артефакт — то, что создается на каждом этапе: task note, brief, design-док, план, код, PR, runbook.
 
 ## Градиент участия человека
 
@@ -37,6 +45,24 @@ audience: humans_and_agents
 Бизнес-требования  ← человек  |  агент →  Код
   PRD, Use Cases      Brief, Design, Plan   PR, Тесты
 ```
+
+## Routing Signature
+
+Перед выбором workflow зафиксируй минимальную подпись задачи. Для маленьких задач подпись может жить в issue/PR; для managed task package - в `memory-bank/tasks/TASK-XXX/`; для feature/epic - в соответствующем package.
+
+| Поле | Значения | Зачем нужно |
+| --- | --- | --- |
+| `kind` | `feature`, `bugfix`, `chore`, `refactor`, `incident`, `epic`, `unknown` | Выбрать семью workflow до создания документов |
+| `size` | `tiny`, `small`, `medium`, `large`, `unknown` | Отделить одно-сессионные изменения от managed delivery |
+| `risk` | `low`, `normal`, `high`, `critical`, `unknown` | Определить, нужен ли durable plan/design/evidence |
+| `change_surface` | `single_component`, `multi_component`, `cross_boundary`, `external`, `unknown` | Понять blast radius |
+| `contract_change` | `none`, `api`, `schema`, `event`, `security`, `financial`, `integration`, `rollout`, `unknown` | Включить promotion triggers |
+| `design_need` | `none`, `local_reasoning`, `required`, `unknown` | Решить, нужен ли `design.md` / ADR / managed package |
+| `evidence_need` | `focused_test`, `regression_test`, `manual_evidence`, `ci_evidence`, `external_e2e`, `unknown` | Выбрать verify carrier |
+| `owner_doc_need` | `none`, `task_note`, `managed_task_package`, `feature_package`, `epic_package`, `unknown` | Выбрать комплект документов |
+| `workflow_profile` | `tracker-only`, `bugfix-compact`, `refactor-small`, `managed-task`, `feature-package`, `epic-package`, `incident-pir`, `unknown` | Зафиксировать итоговый profile selector-а |
+
+Если `kind`, `risk`, `change_surface` или `contract_change` остаются `unknown`, агент не должен молча выбирать самый короткий путь. Нужно либо закрыть неизвестность через discovery, либо поднять задачу до более строгого profile.
 
 ## Типы Workflow
 
@@ -51,6 +77,8 @@ audience: humans_and_agents
 Flow:
 
 `issue/task -> routing -> implementation -> review -> merge`
+
+Для маленькой non-feature задачи используй document profiles ниже, а не full `feature-flow` по умолчанию.
 
 ### 2. Средняя или большая фича
 
@@ -90,6 +118,35 @@ Flow:
 
 Здесь человек обычно подтверждает RCA и приоритеты follow-up задач.
 
+## Document Profiles
+
+Используй минимальный комплект документов, который сохраняет контроль над риском и evidence. `feature-flow` больше не является default для всех задач.
+
+| Profile | Когда применять | Canonical carriers | Не применять, если |
+| --- | --- | --- | --- |
+| `tracker-only` | `tiny/small`, `low` risk, локальная правка без contract change | GitHub issue/PR: routing signature, short rationale, checks/evidence | Нужен durable owner doc, есть design decision или high-risk surface |
+| `bugfix-compact` | Дефект с понятным symptom/repro/root cause и локальным fix | [`bugfix-flow.md`](bugfix-flow.md); GitHub issue/PR по шаблону [`templates/task/bugfix.md`](templates/task/bugfix.md); optional `memory-bank/tasks/TASK-XXX/README.md` + `bugfix.md`, если нужен durable context | Меняется API/schema/security/financial/integration/rollout или root cause требует design reasoning |
+| `refactor-small` | Локальный рефакторинг без изменения поведения | [`refactor-flow.md`](refactor-flow.md); GitHub issue/PR по шаблону [`templates/task/refactor.md`](templates/task/refactor.md); optional `memory-bank/tasks/TASK-XXX/README.md` + `refactor.md`, если нужен durable context | Большой change surface, migration/checkpoints или risk of behavior drift |
+| `managed-task` | Bugfix/chore/refactor больше issue/PR, но еще не feature: нужен scope, invariants, checkpoints, evidence | `memory-bank/tasks/TASK-XXX/` с `bugfix.md` или `refactor.md`; optional linked ADR/runbook/incident docs | Появляется новая user/system capability или устойчивый scenario |
+| `feature-package` | Новая или materially changed capability / delivery slice | `memory-bank/features/FT-XXX/` по [`feature-flow.md`](feature-flow.md) | Требуется roadmap/risk register/subissues для нескольких delivery units |
+| `epic-package` | Инициатива крупнее одной delivery unit | `memory-bank/epics/EP-XXX/` по [`epic-flow.md`](epic-flow.md) | Есть только одна локальная delivery task |
+| `incident-pir` | Инцидент, RCA, prevention work | Incident/PIR docs по project owner-докам | Это обычный дефект без incident/RCA context |
+
+`tracker-only`, `bugfix-compact`, `refactor-small` и `managed-task` используют общий [`task-flow.md`](task-flow.md). Bugfix-процесс описан в [`bugfix-flow.md`](bugfix-flow.md), refactor/chore-процесс - в [`refactor-flow.md`](refactor-flow.md). `memory-bank/tasks/` не заменяет `features/`: он нужен для управляемых non-feature задач, где full feature package создает лишнюю ceremony, но issue/PR уже недостаточны для traceability.
+
+## Promotion Rules
+
+Начинай с минимального profile и повышай его при появлении trigger-а.
+
+| Trigger | Куда повышать | Причина |
+| --- | --- | --- |
+| Меняется API, event, schema, file format, CLI, security boundary, financial calculation, integration contract или operational rollout | `feature-package` или ADR + `feature-package` | Нужен solution-space owner и acceptance traceability |
+| Bugfix требует alternatives/trade-off reasoning, migration strategy, rollout/backout или explicit failure-mode design | `managed-task` или `feature-package` | Issue/PR note перестает быть достаточным owner-ом решения |
+| Refactor затрагивает несколько bounded contexts, shared abstractions или runtime topology | `managed-task` / `feature-package`; для серии задач - `epic-package` | Нужны checkpoints, invariants и stop conditions |
+| Исправление создает новый устойчивый user/operator/system scenario | `feature-package` + обновление `UC-*` при необходимости | Это уже capability, а не только fix/chore |
+| В процессе review появляются повторные замечания о scope/design/evidence | Повысить profile и обновить owner docs до новых правок | Проблема находится upstream, а не в локальном diff |
+| `risk=high/critical` или есть irreversible/external side effects | Минимум `managed-task`, часто `feature-package` | Нужны явные approvals, rollback/backout и durable evidence |
+
 ## Routing Rules
 
 Используй минимальный workflow, который не теряет контроль над риском.
@@ -97,3 +154,4 @@ Flow:
 - Если задача маленькая и понятная, не раздувай её до большого feature package.
 - Если задача меняет контракт, rollout или требует approvals, поднимай её до feature flow.
 - Если замечания не уменьшаются от итерации к итерации, проблема может быть upstream, а не в коде.
+- Если compact profile выбран для bugfix/refactor, PR обязан содержать routing signature и evidence по соответствующему template.

--- a/memory-bank/tasks/README.md
+++ b/memory-bank/tasks/README.md
@@ -1,0 +1,55 @@
+---
+title: Task Packages Index
+doc_kind: task
+doc_function: index
+purpose: "Навигация по compact managed task packages для bugfix/chore/refactor работ, которым нужен durable context, но не нужен full feature package."
+derived_from:
+  - ../dna/governance.md
+  - ../flows/task-flow.md
+  - ../flows/bugfix-flow.md
+  - ../flows/refactor-flow.md
+  - ../flows/workflows.md
+status: active
+audience: humans_and_agents
+---
+
+# Task Packages Index
+
+Каталог `memory-bank/tasks/` хранит compact packages вида `TASK-XXX/` для managed non-feature задач.
+
+## Когда Использовать
+
+Создавай `TASK-XXX/`, если одновременно верно:
+
+- задача является `bugfix`, `chore` или `refactor`, а не новой user/system capability;
+- issue/PR carrier недостаточен для durable traceability;
+- full `feature-flow` создает лишнюю ceremony;
+- нужны scope, non-scope, invariants, checkpoints или evidence, но не нужен полноценный feature `brief.md` + `design.md` + `implementation-plan.md`.
+
+Не используй `TASK-XXX/`, если задача меняет API/schema/security/financial/integration/rollout contract или создает устойчивый scenario. В таком случае используй [`../features/`](../features/) по [`../flows/feature-flow.md`](../flows/feature-flow.md) либо ADR/incident owner docs.
+
+## Комплект Документов
+
+Durable task package ведется по [`../flows/task-flow.md`](../flows/task-flow.md) и содержит:
+
+- `README.md` - routing/index layer, создается по [`../flows/templates/task/package-README.md`](../flows/templates/task/package-README.md);
+- `bugfix.md` - если task является managed bugfix; ведется по [`../flows/bugfix-flow.md`](../flows/bugfix-flow.md);
+- `refactor.md` - если task является managed refactor/chore; ведется по [`../flows/refactor-flow.md`](../flows/refactor-flow.md).
+
+`implementation-plan.md` и `design.md` внутри `TASK-XXX/` не создаются. Если они стали нужны, task нужно повысить до `feature-package`, ADR или `epic-package`.
+
+## Именование
+
+- Базовый формат: `TASK-XXX/`
+- Вместо `XXX` используй GitHub issue id или другой стабильный task id.
+- Один package = одна managed non-feature delivery task.
+
+## Шаблоны
+
+- [`../flows/templates/task/package-README.md`](../flows/templates/task/package-README.md) - routing/index layer для durable `TASK-XXX/`.
+- [`../flows/templates/task/bugfix.md`](../flows/templates/task/bugfix.md) - compact bugfix note.
+- [`../flows/templates/task/refactor.md`](../flows/templates/task/refactor.md) - compact refactor/chore note.
+
+## Созданные Packages
+
+В шаблонном репозитории этот каталог может не содержать instantiated `TASK-XXX/` packages. Это нормально: destination создается как optional owner для downstream managed non-feature задач.


### PR DESCRIPTION
## Summary

- Adds a generic compact task-flow family for non-feature work: `task-flow.md`, `bugfix-flow.md`, and `refactor-flow.md`.
- Adds governed `TASK-XXX` templates and `memory-bank/tasks/README.md` for managed bugfix/chore/refactor tasks.
- Updates workflow routing, navigation indexes, overview docs, dependency tree, and FT-012 feature evidence.

## Why

Issue #12 notes that full feature packages are too heavy for small bugfix/refactor/chore tasks. This adds an intermediate task carrier while preserving promotion triggers for feature, contract, high-risk, design, and multi-delivery-unit work.

Closes #12.

## Checks

- `rg --files memory-bank | sort`
- `python3 scripts/check_memory_bank_index.py`
- `git diff --check`
- `rg -n "alfagen|mercury|TASK-3446|rate-daemon|SlotDiagnostics|PositionAware|production log storm" INTRO.md dependency-tree.md memory-bank/README.md memory-bank/flows memory-bank/tasks`
- `rg -n "workflow_profile|Promotion|promotion|contract_change|feature-package|epic-package|risk=high/critical|design reasoning|contract change" memory-bank/flows/workflows.md memory-bank/flows/task-flow.md memory-bank/flows/bugfix-flow.md memory-bank/flows/refactor-flow.md memory-bank/flows/templates/task memory-bank/tasks/README.md`
